### PR TITLE
rlp: refactor interface

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -21,14 +21,8 @@ const (
 )
 
 func List(items ...Item) Item {
-	if len(items) == 0 {
-		return Item{l: []Item{}}
-	}
-
 	var it Item
-	for i := range items {
-		it.l = append(it.l, items[i])
-	}
+	it.l = append(it.l, items...)		
 	return it
 }
 

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -88,6 +88,13 @@ func (i Item) Uint16() (uint16, error) {
 	return binary.BigEndian.Uint16(i.d), nil
 }
 
+func (i Item) String() (string, error) {
+	if len(i.d) == 0 {
+		return "", errNoData
+	}
+	return string(i.d), nil
+}
+
 func (i Item) Hash() ([32]byte, error) {
 	var h [32]byte
 	if len(i.d) == 0 {

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -54,6 +54,9 @@ func Byte(b byte) Item {
 }
 
 func Bytes(b []byte) Item {
+	if b == nil {
+		return Item{d: []byte{}}
+	}
 	return Item{d: b}
 }
 

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -124,7 +124,7 @@ func Encode(input Item) []byte {
 				input.d...,
 			)
 		default:
-			lengthSize, length := encodeLength(uint64(len(input.D)))
+			lengthSize, length := encodeLength(uint64(len(input.d)))
 			header := append(
 				[]byte{str55H + lengthSize},
 				length...,

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -5,10 +5,29 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"reflect"
 	"testing"
 )
+
+func ExampleEncode() {
+	item := List(
+		String("foo"),
+		List(String("bar"), String("baz")),
+	)
+	item, _ = Decode(Encode(item))
+
+	var (
+		first, _  = item.At(0).String()
+		second, _ = item.At(1).At(0).String()
+		third, _  = item.At(1).At(1).String()
+	)
+	fmt.Println(first, second, third)
+
+	//Output:
+	// foo bar baz
+}
 
 func FuzzEncode(f *testing.F) {
 	var (

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -22,11 +22,7 @@ func FuzzEncode(f *testing.F) {
 			items = append(items, Bytes(d))
 		}
 		item := List(items...)
-		b, err := Encode(item)
-		if err != nil {
-			t.Fatal(err)
-		}
-		got, err := Decode(b)
+		got, err := Decode(Encode(item))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,10 +36,7 @@ func BenchmarkEncode(b *testing.B) {
 	payload := []byte("hello world")
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		_, err := Encode(Bytes(payload))
-		if err != nil {
-			b.Fatal(err)
-		}
+		Encode(Bytes(payload))
 	}
 }
 
@@ -237,11 +230,7 @@ func TestDecode(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		b, err := Encode(tc.item)
-		if err != nil {
-			t.Error(err)
-		}
-		got, err := Decode(b)
+		got, err := Decode(Encode(tc.item))
 		if err != nil {
 			t.Errorf("error %s: %s", tc.desc, err)
 		}
@@ -256,31 +245,26 @@ func TestEncode(t *testing.T) {
 		desc string
 		item Item
 		want []byte
-		err  error
 	}{
 		{
 			"zero byte",
 			Byte(0),
 			[]byte{0x00},
-			nil,
 		},
 		{
 			"int 0",
 			Int(0),
 			[]byte{0x80},
-			nil,
 		},
 		{
 			"int 1024",
 			Int(1024),
 			[]byte{0x82, 0x04, 0x00},
-			nil,
 		},
 		{
 			"empty string",
 			String(""),
 			[]byte{0x80},
-			nil,
 		},
 		{
 			"non-empty string",
@@ -345,13 +329,11 @@ func TestEncode(t *testing.T) {
 				0x69,
 				0x74,
 			},
-			nil,
 		},
 		{
 			"empty list",
 			List(),
 			[]byte{0xc0},
-			nil,
 		},
 		{
 			"list of strings",
@@ -367,7 +349,6 @@ func TestEncode(t *testing.T) {
 				0x6f, // o
 				0x67, // g
 			},
-			nil,
 		},
 		{
 			"the set theoretical representation of three",
@@ -386,16 +367,10 @@ func TestEncode(t *testing.T) {
 				0xc1,
 				0xc0,
 			},
-			nil,
 		},
 	}
 	for _, tc := range cases {
-		got, err := Encode(tc.item)
-		if err != nil {
-			if !errors.Is(err, tc.err) {
-				t.Errorf("%s: want: %v got: %v", tc.desc, tc.err, err)
-			}
-		}
+		got := Encode(tc.item)
 		if !bytes.Equal(tc.want, got) {
 			t.Errorf("%s\nwant:\n%v\ngot:\n%v\n", tc.desc, tc.want, got)
 		}

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -198,6 +198,10 @@ func TestDecode(t *testing.T) {
 		item Item
 	}{
 		{
+			"empty bytes",
+			Bytes(nil),
+		},
+		{
 			"short string",
 			String("a"),
 		},


### PR DESCRIPTION
encoding example:
```go
item := rlp.List(
	rlp.Byte(4),
	rlp.List(
		rlp.Bytes(src.Ip[:]),
		rlp.Uint16(src.UdpPort),
		rlp.Uint16(src.TcpPort),
	),
	rlp.List(
		rlp.Bytes(dest.Ip[:]),
		rlp.Uint16(dest.UdpPort),
		rlp.Uint16(dest.TcpPort),
	),
	rlp.Time(time.Now().Add(time.Hour)),
)
```
decoding example:
```go
item, err := rlp.Decode(packet[headerSize:])
if err != nil {
        return err
}
hash, err := item.At(1).Hash()
if err != nil {
        return err
}
```