### PR TITLE
rlp: fix length encoding

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -79,6 +79,9 @@ func Encode(input *Item) ([]byte, error) {
 
 func encodeLength(t byte, n int) []byte {
 	// Tommy's algorithm
+	if n < 1 {
+		panic("encodeLength only works for non negative integers")
+	}
 	var buf []byte
 	for i := n; i > 0; {
 		buf = append([]byte{byte(i & 0xff)}, buf...)

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -7,7 +7,6 @@ package rlp
 import (
 	"encoding/binary"
 	"errors"
-	"math/bits"
 )
 
 const (
@@ -79,11 +78,12 @@ func Encode(input *Item) ([]byte, error) {
 }
 
 func encodeLength(t byte, n int) []byte {
-	buf := make([]byte, 8)
-	for i := 0; i < 8; i++ {
-		buf[i] = byte(n>>(64-((i+1)*8))) & 0xff
+	// Tommy's algorithm
+	var buf []byte
+	for i := n; i > 0; {
+		buf = append([]byte{byte(i & 0xff)}, buf...)
+		i = i >> 8
 	}
-	buf = buf[bits.LeadingZeros64(uint64(n))/8:] // remove leading zeros
 	return append(
 		[]byte{uint8(t) + uint8(len(buf))},
 		buf...,

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -50,10 +50,12 @@ func Encode(input *Item) ([]byte, error) {
 				input.D...,
 			), nil
 		default:
-			return append(
-				encodeLength(str55H, len(input.D)),
-				input.D...,
-			), nil
+			lengthSize, length := encodeLength(uint64(len(input.D)))
+			header := append(
+				[]byte{str55H + lengthSize},
+				length...,
+			)
+			return append(header, input.D...), nil
 		}
 	}
 
@@ -71,26 +73,22 @@ func Encode(input *Item) ([]byte, error) {
 			out...,
 		), nil
 	}
-	return append(
-		encodeLength(list55H, len(out)),
-		out...,
-	), nil
+	lengthSize, length := encodeLength(uint64(len(out)))
+	header := append(
+		[]byte{list55H + lengthSize},
+		length...,
+	)
+	return append(header, out...), nil
 }
 
-func encodeLength(t byte, n int) []byte {
+func encodeLength(n uint64) (uint8, []byte) {
 	// Tommy's algorithm
-	if n < 1 {
-		panic("encodeLength only works for non negative integers")
-	}
 	var buf []byte
 	for i := n; i > 0; {
 		buf = append([]byte{byte(i & 0xff)}, buf...)
 		i = i >> 8
 	}
-	return append(
-		[]byte{uint8(t) + uint8(len(buf))},
-		buf...,
-	)
+	return uint8(len(buf)), buf
 }
 
 // Returns two values representing the length of the


### PR DESCRIPTION
Taken from the RLP spec:

> ...but positive RLP integers must be represented in big-endian binary form with no leading zeroes (thus making the integer value zero equivalent to the empty byte array)