### PR TITLE
isxsecp256k1: new package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/indexsupply/x
 go 1.19
 
 require (
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=

--- a/isxsecp256k1/secp256k1.go
+++ b/isxsecp256k1/secp256k1.go
@@ -1,0 +1,66 @@
+// isxsecp256k1 provides a wrapper around the secp256k1 package
+// from dcrec --which is an actively maintained codebase built from
+// btcd.
+//
+// Since Ethereum uses secp256k1 in special ways, this package
+// exists to encapsulate the special ways so that it is easier to
+// use the secp256k1 code in the 'right way.'
+//
+// Sign and Recover are constructed from the secp256k1 author's
+// advice: https://github.com/decred/dcrd/issues/2889,
+// https://go.dev/play/p/gIbvbly7n9h
+package isxsecp256k1
+
+import (
+	"errors"
+
+	"github.com/indexsupply/x/isxerrors"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+)
+
+func Sign(k *secp256k1.PrivateKey, d [32]byte) ([65]byte, error) {
+	sig := ecdsa.SignCompact(k, d[:], false)
+	v := sig[0] - 27
+	copy(sig, sig[1:])
+	sig[64] = v
+	if len(sig) != 65 {
+		return [65]byte{}, errors.New("signature must be 65 bytes long")
+	}
+	return *(*[65]byte)(sig), nil
+}
+
+func Recover(sig [65]byte, hash [32]byte) (*secp256k1.PublicKey, error) {
+	if sig[64] >= 4 {
+		return nil, errors.New("invalid signature recovery id")
+	}
+	// Convert from Ethereum signature format with 'recovery id' v at the end.
+	var converted [65]byte
+	copy(converted[1:], sig[:])
+	converted[0] = sig[64] + 27
+
+	pub, _, err := ecdsa.RecoverCompact(converted[:], hash[:])
+	if err != nil {
+		return nil, isxerrors.Errorf("recovering pubkey: %w", err)
+	}
+	return pub, nil
+}
+
+func Encode(pubkey *secp256k1.PublicKey) [64]byte {
+	// SerializeUncompressed returns:
+	// 0x04 || 32-byte x coordinate || 32-byte y coordinate
+	var b [64]byte
+	ucpk := pubkey.SerializeUncompressed()
+	copy(b[:], ucpk[1:])
+	return b
+}
+
+func Decode(d [64]byte) (*secp256k1.PublicKey, error) {
+	b := append([]byte{0x04}, d[:]...)
+	return secp256k1.ParsePubKey(b)
+}
+
+func DecodeCompressed(d [33]byte) (*secp256k1.PublicKey, error) {
+	return secp256k1.ParsePubKey(d[:])
+}

--- a/isxsecp256k1/secp256k1_test.go
+++ b/isxsecp256k1/secp256k1_test.go
@@ -1,0 +1,35 @@
+package isxsecp256k1
+
+import (
+	"testing"
+
+	"github.com/indexsupply/x/tc"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+func TestSignRecover(t *testing.T) {
+	prv, err := secp256k1.GeneratePrivateKey()
+	tc.NoErr(t, err)
+	h := [32]byte{}
+	sig, err := Sign(prv, h)
+	tc.NoErr(t, err)
+	pub, err := Recover(sig, h)
+	tc.NoErr(t, err)
+	if !pub.IsEqual(prv.PubKey()) {
+		t.Error("expected pub key to match")
+	}
+}
+
+func TestEncodeDecode(t *testing.T) {
+	prv, err := secp256k1.GeneratePrivateKey()
+	tc.NoErr(t, err)
+	got, err := Decode(Encode(prv.PubKey()))
+	tc.NoErr(t, err)
+	if !prv.PubKey().IsEqual(got) {
+		t.Errorf("want: %x got: %x",
+			prv.PubKey().SerializeCompressed(),
+			got.SerializeCompressed(),
+		)
+	}
+}


### PR DESCRIPTION
The interface in this package uses fixed length arrays -- which may turn out to be annoying. But I had this thought that having the compiler check input/output sizes would ultimately lead to safer crypto code.