### PR TITLE
rlp: refactor. use encodeUint for type helpers

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -59,7 +59,7 @@ func Encode(input Item) []byte {
 				input.d...,
 			)
 		default:
-			lengthSize, length := encodeLength(uint64(len(input.d)))
+			lengthSize, length := encodeUint(uint64(len(input.d)))
 			header := append(
 				[]byte{str55H + lengthSize},
 				length...,
@@ -78,7 +78,7 @@ func Encode(input Item) []byte {
 			out...,
 		)
 	}
-	lengthSize, length := encodeLength(uint64(len(out)))
+	lengthSize, length := encodeUint(uint64(len(out)))
 	header := append(
 		[]byte{list55H + lengthSize},
 		length...,
@@ -86,7 +86,7 @@ func Encode(input Item) []byte {
 	return append(header, out...)
 }
 
-func encodeLength(n uint64) (uint8, []byte) {
+func encodeUint(n uint64) (uint8, []byte) {
 	// Tommy's algorithm
 	var buf []byte
 	for i := n; i > 0; {

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -119,7 +119,7 @@ func TestDecode_Errors(t *testing.T) {
 	}
 }
 
-func TestEncodeLength(t *testing.T) {
+func TestEncodeUint(t *testing.T) {
 	cases := []struct {
 		desc string
 		n    uint64
@@ -152,7 +152,7 @@ func TestEncodeLength(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		lengthSize, length := encodeLength(tc.n)
+		lengthSize, length := encodeUint(tc.n)
 		if lengthSize != tc.l {
 			t.Errorf("%s: expected: %d got: %d", tc.desc, tc.l, lengthSize)
 		}

--- a/rlp/types.go
+++ b/rlp/types.go
@@ -3,7 +3,6 @@ package rlp
 import (
 	"encoding/binary"
 	"errors"
-	"math/big"
 	"net/netip"
 	"time"
 )
@@ -25,9 +24,8 @@ func (i Item) Bytes() ([]byte, error) {
 }
 
 func Uint16(n uint16) Item {
-	buf := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf[:], n)
-	return Item{d: buf[:2]}
+	_, b := encodeUint(uint64(n))
+	return Item{d: b}
 }
 
 func (i Item) Uint16() (uint16, error) {
@@ -38,9 +36,8 @@ func (i Item) Uint16() (uint16, error) {
 }
 
 func Uint64(n uint64) Item {
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf[:], n)
-	return Item{d: buf[4:8]}
+	_, b := encodeUint(n)
+	return Item{d: b}
 }
 
 func (i Item) Uint64() (uint64, error) {
@@ -106,8 +103,8 @@ func Byte(b byte) Item {
 }
 
 func Int(n int) Item {
-	bi := big.NewInt(int64(n))
-	return Item{d: bi.Bytes()}
+	_, b := encodeUint(uint64(n))
+	return Item{d: b}
 }
 
 // left pads the provided byte array to the wantedLength, in bytes, using 0s.


### PR DESCRIPTION
We have a pretty great function for turning integers into byte slices. So we can use that instead of stitching together various stdlib functions.