### PR TITLE
bint: fix decode padding and encoding uint64(0)

### DIFF
--- a/bint/binary_test.go
+++ b/bint/binary_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDecode(t *testing.T) {
-	var cases = []uint8{0, 8, 16, 32, 64}
+	var cases = []uint8{8, 16, 32, 64}
 	for _, e := range cases {
 		i := uint64(1<<e - 1)
 		b, n := Encode(nil, i)
@@ -17,6 +17,30 @@ func TestDecode(t *testing.T) {
 		if got != i {
 			t.Errorf("expected %d got: %d", i, got)
 		}
+	}
+}
+
+func TestDecode_0(t *testing.T) {
+	b, n := Encode(nil, 0)
+	if n != 1 {
+		t.Errorf("expected 0 to be 1 byte got: %d", n)
+	}
+	if b[0] != 0 {
+		t.Errorf("expected 0 to encode to 0x00 bot: %x", b[0])
+	}
+
+	got := Decode(b)
+	exp := uint64(0)
+	if exp != got {
+		t.Errorf("expected: %d got: %d", exp, got)
+	}
+}
+
+func TestDecode_Pad(t *testing.T) {
+	got := Decode([]byte{0x00, 0x00, 0x01, 0x00})
+	exp := uint64(256)
+	if exp != got {
+		t.Errorf("expected: %d got: %d", exp, got)
 	}
 }
 

--- a/bint/bint.go
+++ b/bint/bint.go
@@ -1,3 +1,4 @@
+// big endian, uint64 binary encoding/decoding
 package bint
 
 // Encodes a uint64 into a big-endian byte slice
@@ -7,9 +8,6 @@ func Encode(b []byte, n uint64) ([]byte, uint8) {
 	if b == nil {
 		b = make([]byte, size(n))
 	}
-	if n == 0 {
-		return b, 0
-	}
 	for i := uint64(0); n > 0; i++ {
 		b[i] = byte(n & 0xff)
 		n = n >> 8
@@ -17,20 +15,22 @@ func Encode(b []byte, n uint64) ([]byte, uint8) {
 	return b, uint8(len(b))
 }
 
-func size(n uint64) uint8 {
-	var s uint8
+func size(n uint64) (s uint8) {
+	if n == 0 {
+		return 1
+	}
 	for n > 0 {
 		n = n >> 8
 		s++
 	}
-	return s
+	return
 }
 
 // Decodes big-endian byte array into a uint64
-// Right-padded zero bytes are ignored.
+// left-padded zero bytes are ignored.
 func Decode(b []byte) uint64 {
 	var n uint64
-	for i := 0; i < len(b) && b[i] != 0; i++ {
+	for i := 0; i < len(b); i++ {
 		n = n << 8
 		n += uint64(b[i])
 	}


### PR DESCRIPTION
A silly mistake in which I wrote the decode method to ignore right padded zeros.
Also, Encode returns `[0x0], 1` for `uint64(0)`
Both of these issues were mistakes I made while coding this package.