### PR TITLE
bint: fix bug for padded results

### DIFF
--- a/bint/binary_test.go
+++ b/bint/binary_test.go
@@ -69,13 +69,14 @@ func TestEncodeBuf(t *testing.T) {
 }
 
 func TestEncodeBuf_Pad(t *testing.T) {
-	b := make([]byte, 4)
+	got := make([]byte, 4)
 	i := uint64(1<<16 - 1)
-	_, n := Encode(b[:], i)
+	_, n := Encode(got[:], i)
 	if n != 4 {
-		t.Errorf("expected %d to use 2 bytes. got: %d", i, n)
+		t.Errorf("expected %d to use 4 bytes. got: %d", i, n)
 	}
-	if !bytes.Equal(b, []byte{0xff, 0xff, 0x00, 0x00}) {
-		t.Errorf("expected %d to be encoded as: ffff got: %x", i, b)
+	exp := []byte{0x00, 0x00, 0xff, 0xff}
+	if !bytes.Equal(exp, got) {
+		t.Errorf("expected %d to be %x got: %x:", i, exp, got)
 	}
 }

--- a/bint/bint.go
+++ b/bint/bint.go
@@ -8,7 +8,7 @@ func Encode(b []byte, n uint64) ([]byte, uint8) {
 	if b == nil {
 		b = make([]byte, size(n))
 	}
-	for i := uint64(0); n > 0; i++ {
+	for i := len(b) - 1; n > 0; i-- {
 		b[i] = byte(n & 0xff)
 		n = n >> 8
 	}


### PR DESCRIPTION
Was using little endian instead of big endian