### PR TITLE
rlp: use bint package for integer encoding

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -5,8 +5,9 @@
 package rlp
 
 import (
-	"encoding/binary"
 	"errors"
+
+	"github.com/indexsupply/x/bint"
 )
 
 const (
@@ -51,6 +52,8 @@ func Encode(input Item) []byte {
 	}
 	if input.d != nil {
 		switch n := len(input.d); {
+		case n == 1 && input.d[0] == 0:
+			return []byte{0x80}
 		case n == 1 && input.d[0] <= str1H:
 			return input.d
 		case n <= 55:
@@ -59,7 +62,7 @@ func Encode(input Item) []byte {
 				input.d...,
 			)
 		default:
-			lengthSize, length := encodeUint(uint64(len(input.d)))
+			length, lengthSize := encodeLength(len(input.d))
 			header := append(
 				[]byte{str55H + lengthSize},
 				length...,
@@ -78,7 +81,7 @@ func Encode(input Item) []byte {
 			out...,
 		)
 	}
-	lengthSize, length := encodeUint(uint64(len(out)))
+	length, lengthSize := encodeLength(len(out))
 	header := append(
 		[]byte{list55H + lengthSize},
 		length...,
@@ -86,29 +89,19 @@ func Encode(input Item) []byte {
 	return append(header, out...)
 }
 
-func encodeUint(n uint64) (uint8, []byte) {
+func encodeLength(n int) ([]byte, uint8) {
 	if n == 0 {
-		return 0, []byte{}
+		return []byte{}, 0
 	}
-	// Tommy's algorithm
-	var buf []byte
-	for i := n; i > 0; {
-		buf = append([]byte{byte(i & 0xff)}, buf...)
-		i = i >> 8
-	}
-	return uint8(len(buf)), buf
+	return bint.Encode(nil, uint64(n))
 }
 
 // Returns two values representing the length of the
 // header and payload respectively.
 func decodeLength(t byte, input []byte) (int, int) {
-	n := input[0] - t
-	paddedBytes := make([]byte, 8)
-	// binary.BigEndian.Uint64 expects an 8 byte array so we have to left pad
-	// it in case the length is less. Big-endian format is used.
-	copy(paddedBytes[8-n:], input[1:n+1])
-	length := binary.BigEndian.Uint64(paddedBytes)
-	return int(n + 1), int(length)
+	n := (input[0] - t) + 1 //add 1 byte for length size (input[0])
+	l := bint.Decode(input[1:n])
+	return int(n), int(l)
 }
 
 var (

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math"
 	"reflect"
 	"testing"
 )
@@ -115,49 +114,6 @@ func TestDecode_Errors(t *testing.T) {
 			if !errors.Is(tc.err, err) {
 				t.Errorf("expected %v got %v", tc.err, err)
 			}
-		}
-	}
-}
-
-func TestEncodeUint(t *testing.T) {
-	cases := []struct {
-		desc string
-		n    uint64
-		l    uint8
-		b    []byte
-	}{
-		{
-			"0",
-			0,
-			0,
-			[]byte{},
-		},
-		{
-			"1 byte",
-			1,
-			1,
-			[]byte{0x01},
-		},
-		{
-			"2 bytes",
-			256,
-			2,
-			[]byte{0x01, 0x00},
-		},
-		{
-			"max. 8 bytes",
-			math.MaxUint64,
-			8,
-			[]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-		},
-	}
-	for _, tc := range cases {
-		lengthSize, length := encodeUint(tc.n)
-		if lengthSize != tc.l {
-			t.Errorf("%s: expected: %d got: %d", tc.desc, tc.l, lengthSize)
-		}
-		if !bytes.Equal(length, tc.b) {
-			t.Errorf("%s: expected: %x got: %x", tc.desc, tc.b, length)
 		}
 	}
 }

--- a/rlp/types.go
+++ b/rlp/types.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/indexsupply/x/bint"
 	"github.com/indexsupply/x/isxsecp256k1"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -29,7 +30,7 @@ func (i Item) Bytes() ([]byte, error) {
 }
 
 func Uint16(n uint16) Item {
-	_, b := encodeUint(uint64(n))
+	b, _ := bint.Encode(nil, uint64(n))
 	return Item{d: b}
 }
 
@@ -41,7 +42,7 @@ func (i Item) Uint16() (uint16, error) {
 }
 
 func Uint64(n uint64) Item {
-	_, b := encodeUint(n)
+	b, _ := bint.Encode(nil, n)
 	return Item{d: b}
 }
 
@@ -124,7 +125,7 @@ func Byte(b byte) Item {
 }
 
 func Int(n int) Item {
-	_, b := encodeUint(uint64(n))
+	b, _ := bint.Encode(nil, uint64(n))
 	return Item{d: b}
 }
 


### PR DESCRIPTION
One big change here is that Encode now has to account for the 0 byte --which is 0x80 per the RLP spec. Previously, we were relying on integer encoding return an empty byte array for 0. However, bint encode 0 as [0x00].