### PR TITLE
bint: simplify encode interface. remove length from return

### DIFF
--- a/bint/binary_test.go
+++ b/bint/binary_test.go
@@ -9,7 +9,8 @@ func TestDecode(t *testing.T) {
 	var cases = []uint8{8, 16, 32, 64}
 	for _, e := range cases {
 		i := uint64(1<<e - 1)
-		b, n := Encode(nil, i)
+		b := Encode(nil, i)
+		n := uint8(len(b))
 		if n != e/8 {
 			t.Errorf("num bytes expected %d got: %d", e/8, n)
 		}
@@ -21,7 +22,8 @@ func TestDecode(t *testing.T) {
 }
 
 func TestDecode_0(t *testing.T) {
-	b, n := Encode(nil, 0)
+	b := Encode(nil, 0)
+	n := len(b)
 	if n != 1 {
 		t.Errorf("expected 0 to be 1 byte got: %d", n)
 	}
@@ -46,7 +48,8 @@ func TestDecode_Pad(t *testing.T) {
 
 func TestEncodeNil(t *testing.T) {
 	i := uint64(1<<16 - 1)
-	b, n := Encode(nil, i)
+	b := Encode(nil, i)
+	n := len(b)
 	if n != 2 {
 		t.Errorf("expected %d to use 2 bytes. got: %d", i, n)
 	}
@@ -58,10 +61,7 @@ func TestEncodeNil(t *testing.T) {
 func TestEncodeBuf(t *testing.T) {
 	b := make([]byte, 2)
 	i := uint64(1<<16 - 1)
-	_, n := Encode(b[:], i)
-	if n != 2 {
-		t.Errorf("expected %d to use 2 bytes. got: %d", i, n)
-	}
+	Encode(b[:], i)
 	if !bytes.Equal(b, []byte{0xff, 0xff}) {
 		t.Errorf("expected %d to be encoded as: ffff got: %x", i, b)
 	}
@@ -71,10 +71,7 @@ func TestEncodeBuf(t *testing.T) {
 func TestEncodeBuf_Pad(t *testing.T) {
 	got := make([]byte, 4)
 	i := uint64(1<<16 - 1)
-	_, n := Encode(got[:], i)
-	if n != 4 {
-		t.Errorf("expected %d to use 4 bytes. got: %d", i, n)
-	}
+	Encode(got[:], i)
 	exp := []byte{0x00, 0x00, 0xff, 0xff}
 	if !bytes.Equal(exp, got) {
 		t.Errorf("expected %d to be %x got: %x:", i, exp, got)

--- a/bint/bint.go
+++ b/bint/bint.go
@@ -4,7 +4,7 @@ package bint
 // Encodes a uint64 into a big-endian byte slice
 // To avoid an allocation, or to have a padded result,
 // supply an initialized value for b -otherwise use nil.
-func Encode(b []byte, n uint64) ([]byte, uint8) {
+func Encode(b []byte, n uint64) []byte {
 	if b == nil {
 		b = make([]byte, size(n))
 	}
@@ -12,7 +12,7 @@ func Encode(b []byte, n uint64) ([]byte, uint8) {
 		b[i] = byte(n & 0xff)
 		n = n >> 8
 	}
-	return b, uint8(len(b))
+	return b
 }
 
 func size(n uint64) (s uint8) {

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -93,7 +93,8 @@ func encodeLength(n int) ([]byte, uint8) {
 	if n == 0 {
 		return []byte{}, 0
 	}
-	return bint.Encode(nil, uint64(n))
+	b := bint.Encode(nil, uint64(n))
+	return b, uint8(len(b))
 }
 
 // Returns two values representing the length of the

--- a/rlp/types.go
+++ b/rlp/types.go
@@ -30,8 +30,7 @@ func (i Item) Bytes() ([]byte, error) {
 }
 
 func Uint16(n uint16) Item {
-	b, _ := bint.Encode(nil, uint64(n))
-	return Item{d: b}
+	return Item{d: bint.Encode(nil, uint64(n))}
 }
 
 func (i Item) Uint16() (uint16, error) {
@@ -42,8 +41,7 @@ func (i Item) Uint16() (uint16, error) {
 }
 
 func Uint64(n uint64) Item {
-	b, _ := bint.Encode(nil, n)
-	return Item{d: b}
+	return Item{d: bint.Encode(nil, n)}
 }
 
 func (i Item) Uint64() (uint64, error) {
@@ -125,8 +123,7 @@ func Byte(b byte) Item {
 }
 
 func Int(n int) Item {
-	b, _ := bint.Encode(nil, uint64(n))
-	return Item{d: b}
+	return Item{d: bint.Encode(nil, uint64(n))}
 }
 
 // left pads the provided byte array to the wantedLength, in bytes, using 0s.


### PR DESCRIPTION
The length can easily be checked by calling len() on the returned bytes. 
In the case where the caller is passing a pre-allocated buffer, 
the caller may already know the length without calling len().