### PR TITLE
rlpx: parse auth message and send ack

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -155,11 +155,7 @@ func Decode(input []byte) (Item, error) {
 			// header's length. In this case, instead
 			// of returning an error, we simply remove
 			// the extra bytes.
-<<<<<<< HEAD
 			input = input[:i+listSize]
-=======
-			input = input[: i+listSize]
->>>>>>> 01b3363 (fix test)
 		}
 
 		item := Item{l: []Item{}}

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -155,7 +155,11 @@ func Decode(input []byte) (Item, error) {
 			// header's length. In this case, instead
 			// of returning an error, we simply remove
 			// the extra bytes.
+<<<<<<< HEAD
 			input = input[:i+listSize]
+=======
+			input = input[: i+listSize]
+>>>>>>> 01b3363 (fix test)
 		}
 
 		item := Item{l: []Item{}}

--- a/rlpx/handshake.go
+++ b/rlpx/handshake.go
@@ -66,10 +66,8 @@ func (h *handshake) createAuthMsg() (rlp.Item, error) {
 			return rlp.Item{}, err
 		}
 	}
-	// Create shared secret using ephemeral key and remote pub key
-	payload := signaturePayload(h.localPrvKey, h.remotePubKey, h.initNonce)
 	// Sig = Sign(Ephemeral Private Key, Shared Secret ^ Nonce)
-	sig, err := isxsecp256k1.Sign(h.localEphPrvKey, payload)
+	sig, err := isxsecp256k1.Sign(h.localEphPrvKey, signaturePayload(h.localPrvKey, h.remotePubKey, h.initNonce))
 	if err != nil {
 		return rlp.Item{}, err
 	}

--- a/rlpx/handshake.go
+++ b/rlpx/handshake.go
@@ -3,7 +3,7 @@ package rlpx
 import (
 	"crypto/rand"
 	"errors"
-	// mrand "math/rand"
+	mrand "math/rand"
 	"net"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -207,9 +207,9 @@ func (h *handshake) seal(body rlp.Item) ([]byte, error) {
 	if h.remotePubKey == nil {
 		return nil, errors.New("unable to encrypt, missing remote pub key")
 	}
-	encBody := rlp.Encode(body)
 	// pad with random data. needs at least 100 bytes to make it indistinguishable from pre-eip-8 handshakes
-	// encBody = append(encBody, make([]byte, mrand.Intn(100)+100)...)
+	encBody := rlp.Encode(body)
+	encBody = append(encBody, make([]byte, mrand.Intn(100)+100)...)
 
 	prefix := make([]byte, prefixLength) // prefix is length of the ciphertext + overhead
 	prefix = bint.Encode(prefix, uint64(len(encBody)+ecies.Overhead))

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -1,7 +1,6 @@
 package rlpx
 
 import (
-	"bytes"
 	"encoding/hex"
 	"net"
 	"testing"
@@ -39,7 +38,7 @@ func TestHandshake(t *testing.T) {
 		if isxsecp256k1.Encode(rh.remoteEphPubKey) != isxsecp256k1.Encode(ih.localEphPrvKey.PubKey()) {
 			t.Errorf("initiator ephemeral pub keys do not match: receiver got %x. expected %x", isxsecp256k1.Encode(rh.remoteEphPubKey), isxsecp256k1.Encode(ih.localEphPrvKey.PubKey()))
 		}
-		if !bytes.Equal(rh.initNonce, ih.initNonce) {
+		if rh.initNonce != ih.initNonce {
 			t.Errorf("initiator nonces do not match: receiver got %d and initiator got %d", rh.initNonce, ih.initNonce)
 		}
 		close(ch)
@@ -52,7 +51,7 @@ func TestHandshake(t *testing.T) {
 	tc.NoErr(t, err)
 	err = ih.handleAckMsg(sealedAck)
 	tc.NoErr(t, err)
-	if !bytes.Equal(ih.receiverNonce, rh.receiverNonce) {
+	if ih.receiverNonce != rh.receiverNonce {
 		t.Errorf("receiver nonces do not match: receiver got %d and initiator got %d", rh.receiverNonce, ih.receiverNonce)
 	}
 	if isxsecp256k1.Encode(ih.remoteEphPubKey) != isxsecp256k1.Encode(rh.localEphPrvKey.PubKey()) {

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 
 	"github.com/indexsupply/x/isxsecp256k1"
+	"github.com/indexsupply/x/enr"
 	"github.com/indexsupply/x/tc"
 )
 
@@ -72,33 +73,22 @@ func decodeHexString(t *testing.T, s string) []byte {
 
 func setupHandshakes(t *testing.T, tv map[string]string) (ih, rh *handshake) {
 	initPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_private_key"]))
-	initEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_ephemeral_private_key"]))
-	initNonce := decodeHexString(t, tv["initiator_nonce"])
-	if len(initNonce) != 32 {
-		t.Errorf("initiator nonce is not 32 bytes")
-	}
-	inonce := make([]byte, 32)
-	copy(inonce[:], initNonce)
+	// initEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_ephemeral_private_key"]))
+	// initNonce := decodeHexString(t, tv["initiator_nonce"])
+	// if len(initNonce) != 32 {
+	// 	t.Errorf("initiator nonce is not 32 bytes")
+	// }
+	// inonce := make([]byte, 32)
+	// copy(inonce[:], initNonce)
 	recPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_private_key"]))
-	recEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_ephemeral_private_key"]))
-	recNonce := decodeHexString(t, tv["receiver_nonce"])
-	if len(recNonce) != 32 {
-		t.Errorf("receiver nonce is not 32 bytes")
-	}
-	rnonce := make([]byte, 32)
-	copy(rnonce[:], recNonce)
-	ih = &handshake{
-		isInitiator:    true,
-		remotePubKey:   recPrvKey.PubKey(),
-		localPrvKey:    initPrvKey,
-		localEphPrvKey: initEphPrvKey,
-		initNonce:      inonce,
-	}
-	rh = &handshake{
-		remotePubKey:   initPrvKey.PubKey(),
-		localPrvKey:    recPrvKey,
-		localEphPrvKey: recEphPrvKey,
-		receiverNonce:  rnonce,
-	}
+	// recEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_ephemeral_private_key"]))
+	// recNonce := decodeHexString(t, tv["receiver_nonce"])
+	// if len(recNonce) != 32 {
+	// 	t.Errorf("receiver nonce is not 32 bytes")
+	// }
+	// rnonce := make([]byte, 32)
+	// copy(rnonce[:], recNonce)
+	ih = newHandshake(initPrvKey, &enr.Record{PublicKey: recPrvKey.PubKey()})
+	rh = newHandshake(recPrvKey, &enr.Record{PublicKey: initPrvKey.PubKey()})
 	return
 }

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 
-	"github.com/indexsupply/x/isxsecp256k1"
 	"github.com/indexsupply/x/enr"
+	"github.com/indexsupply/x/isxsecp256k1"
 	"github.com/indexsupply/x/tc"
 )
 

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -32,6 +32,9 @@ func TestHandshake(t *testing.T) {
 		tc.NoErr(t, err)
 		err = rh.handleAuthMsg(sealedAuth[:br], recConn)
 		tc.NoErr(t, err)
+		if rh.isInitiator {
+			t.Errorf("isInitiator should be false, got true")
+		}
 		// ensure that the nonce, remote pub key and remote ephemeral pub key are set
 		if isxsecp256k1.Encode(rh.remotePubKey) != isxsecp256k1.Encode(ih.localPrvKey.PubKey()) {
 			t.Errorf("initiator pub keys do not match: receiver got %x. expected %x", isxsecp256k1.Encode(rh.remotePubKey), isxsecp256k1.Encode(ih.localPrvKey.PubKey()))
@@ -92,7 +95,6 @@ func setupHandshakes(t *testing.T, tv map[string]string) (ih, rh *handshake) {
 		initNonce:      inonce,
 	}
 	rh = &handshake{
-		isInitiator:    false,
 		remotePubKey:   initPrvKey.PubKey(),
 		localPrvKey:    recPrvKey,
 		localEphPrvKey: recEphPrvKey,

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -1,18 +1,18 @@
 package rlpx
 
 import (
+	"bytes"
 	"encoding/hex"
-	"fmt"
 	"net"
 	"testing"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 
-	_ "github.com/indexsupply/x/ecies"
+	"github.com/indexsupply/x/isxsecp256k1"
 	"github.com/indexsupply/x/tc"
 )
 
-func TestSendAuth(t *testing.T) {
+func TestHandshake(t *testing.T) {
 	tv := map[string]string{
 		"initiator_private_key":           "49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee",
 		"receiver_private_key":            "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291",
@@ -21,37 +21,82 @@ func TestSendAuth(t *testing.T) {
 		"initiator_nonce":                 "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6",
 		"receiver_nonce":                  "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291",
 	}
-	initPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_private_key"]))
-	initEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_ephemeral_private_key"]))
-	initNonce := decodeHexString(t, tv["initiator_nonce"])
-	if len(initNonce) != 32 {
-		t.Errorf("initNonce is not 32 bytes")
-	}
-	nonce := make([]byte, 32)
-	copy(nonce[:], initNonce)
-	recPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_private_key"]))
-	recEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_ephemeral_private_key"]))
-	h := &handshake{
-		isInitiator:     true,
-		remotePubKey:    recPrvKey.PubKey(),
-		localPrvKey:     initPrvKey,
-		localEphPrvKey:  initEphPrvKey,
-		remoteEphPubKey: recEphPrvKey.PubKey(),
-		initNonce:       nonce,
-	}
-	initConn, respConn := net.Pipe()
-	go func() {
-		err := h.sendAuth(initConn)
+	ih, rh := setupHandshakes(t, tv)
+	initConn, recConn := net.Pipe()
+	ch := make(chan struct{})
+
+	// launch the receiver
+	go func(t *testing.T) {
+		sealedAuth := make([]byte, 1024)
+		br, err := recConn.Read(sealedAuth)
 		tc.NoErr(t, err)
-	}()
-	b := make([]byte, 1024)
-	respConn.Read(b)
-	// this test is WIP. Will complete it after we have implemented
-	// logic to respond to an auth message with an ack.
+		err = rh.handleAuthMsg(sealedAuth[:br], recConn)
+		tc.NoErr(t, err)
+		// ensure that the nonce, remote pub key and remote ephemeral pub key are set
+		if isxsecp256k1.Encode(rh.remotePubKey) != isxsecp256k1.Encode(ih.localPrvKey.PubKey()) {
+			t.Errorf("initiator pub keys do not match: receiver got %x. expected %x", isxsecp256k1.Encode(rh.remotePubKey), isxsecp256k1.Encode(ih.localPrvKey.PubKey()))
+		}
+		if isxsecp256k1.Encode(rh.remoteEphPubKey) != isxsecp256k1.Encode(ih.localEphPrvKey.PubKey()) {
+			t.Errorf("initiator ephemeral pub keys do not match: receiver got %x. expected %x", isxsecp256k1.Encode(rh.remoteEphPubKey), isxsecp256k1.Encode(ih.localEphPrvKey.PubKey()))
+		}
+		if !bytes.Equal(rh.initNonce, ih.initNonce) {
+			t.Errorf("initiator nonces do not match: receiver got %d and initiator got %d", rh.initNonce, ih.initNonce)
+		}
+		close(ch)
+	}(t)
+
+	err := ih.sendAuth(initConn)
+	tc.NoErr(t, err)
+	sealedAck := make([]byte, 1024)
+	_, err = initConn.Read(sealedAck)
+	tc.NoErr(t, err)
+	err = ih.handleAckMsg(sealedAck)
+	// tc.NoErr(t, err)
+	if !bytes.Equal(ih.receiverNonce, rh.receiverNonce) {
+		t.Errorf("receiver nonces do not match: receiver got %d and initiator got %d", rh.receiverNonce, ih.receiverNonce)
+	}
+	if isxsecp256k1.Encode(ih.remoteEphPubKey) != isxsecp256k1.Encode(rh.localEphPrvKey.PubKey()) {
+		t.Errorf("receiver ephemeral pub keys do not match: initiator got %x. expected %x", isxsecp256k1.Encode(ih.remoteEphPubKey), isxsecp256k1.Encode(rh.localEphPrvKey.PubKey()))
+	}
+	<-ch
 }
 
 func decodeHexString(t *testing.T, s string) []byte {
 	b, err := hex.DecodeString(s)
 	tc.NoErr(t, err)
 	return b
+}
+
+func setupHandshakes(t *testing.T, tv map[string]string) (ih, rh *handshake) {
+	initPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_private_key"]))
+	initEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_ephemeral_private_key"]))
+	initNonce := decodeHexString(t, tv["initiator_nonce"])
+	if len(initNonce) != 32 {
+		t.Errorf("initiator nonce is not 32 bytes")
+	}
+	inonce := make([]byte, 32)
+	copy(inonce[:], initNonce)
+	recPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_private_key"]))
+	recEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_ephemeral_private_key"]))
+	recNonce := decodeHexString(t, tv["receiver_nonce"])
+	if len(recNonce) != 32 {
+		t.Errorf("receiver nonce is not 32 bytes")
+	}
+	rnonce := make([]byte, 32)
+	copy(rnonce[:], recNonce)
+	ih = &handshake{
+		isInitiator:    true,
+		remotePubKey:   recPrvKey.PubKey(),
+		localPrvKey:    initPrvKey,
+		localEphPrvKey: initEphPrvKey,
+		initNonce:      inonce,
+	}
+	rh = &handshake{
+		isInitiator:    false,
+		remotePubKey:   initPrvKey.PubKey(),
+		localPrvKey:    recPrvKey,
+		localEphPrvKey: recEphPrvKey,
+		receiverNonce:  rnonce,
+	}
+	return
 }

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -23,7 +23,7 @@ func TestHandshake(t *testing.T) {
 	ch := make(chan struct{})
 
 	// launch the receiver
-	go func(t *testing.T) {
+	go func() {
 		sealedAuth := make([]byte, 1024)
 		br, err := recConn.Read(sealedAuth)
 		tc.NoErr(t, err)
@@ -43,7 +43,7 @@ func TestHandshake(t *testing.T) {
 			t.Errorf("initiator nonces do not match: receiver got %d and initiator got %d", rh.initNonce, ih.initNonce)
 		}
 		close(ch)
-	}(t)
+	}()
 
 	err := ih.sendAuth(initConn)
 	tc.NoErr(t, err)

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -15,12 +15,8 @@ import (
 
 func TestHandshake(t *testing.T) {
 	tv := map[string]string{
-		"initiator_private_key":           "49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee",
-		"receiver_private_key":            "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291",
-		"initiator_ephemeral_private_key": "869d6ecf5211f1cc60418a13b9d870b22959d0c16f02bec714c960dd2298a32d",
-		"receiver_ephemeral_private_key":  "e238eb8e04fee6511ab04c6dd3c89ce097b11f25d584863ac2b6d5b35b1847e4",
-		"initiator_nonce":                 "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6",
-		"receiver_nonce":                  "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291",
+		"initiator_private_key": "49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee",
+		"receiver_private_key":  "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291",
 	}
 	ih, rh := setupHandshakes(t, tv)
 	initConn, recConn := net.Pipe()
@@ -73,21 +69,7 @@ func decodeHexString(t *testing.T, s string) []byte {
 
 func setupHandshakes(t *testing.T, tv map[string]string) (ih, rh *handshake) {
 	initPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_private_key"]))
-	// initEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["initiator_ephemeral_private_key"]))
-	// initNonce := decodeHexString(t, tv["initiator_nonce"])
-	// if len(initNonce) != 32 {
-	// 	t.Errorf("initiator nonce is not 32 bytes")
-	// }
-	// inonce := make([]byte, 32)
-	// copy(inonce[:], initNonce)
 	recPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_private_key"]))
-	// recEphPrvKey := secp256k1.PrivKeyFromBytes(decodeHexString(t, tv["receiver_ephemeral_private_key"]))
-	// recNonce := decodeHexString(t, tv["receiver_nonce"])
-	// if len(recNonce) != 32 {
-	// 	t.Errorf("receiver nonce is not 32 bytes")
-	// }
-	// rnonce := make([]byte, 32)
-	// copy(rnonce[:], recNonce)
 	ih = newHandshake(initPrvKey, &enr.Record{PublicKey: recPrvKey.PubKey()})
 	rh = newHandshake(recPrvKey, &enr.Record{PublicKey: initPrvKey.PubKey()})
 	return

--- a/rlpx/handshake_test.go
+++ b/rlpx/handshake_test.go
@@ -51,7 +51,7 @@ func TestHandshake(t *testing.T) {
 	_, err = initConn.Read(sealedAck)
 	tc.NoErr(t, err)
 	err = ih.handleAckMsg(sealedAck)
-	// tc.NoErr(t, err)
+	tc.NoErr(t, err)
 	if !bytes.Equal(ih.receiverNonce, rh.receiverNonce) {
 		t.Errorf("receiver nonces do not match: receiver got %d and initiator got %d", rh.receiverNonce, ih.receiverNonce)
 	}


### PR DESCRIPTION
* Parse the auth handshake message to extract the init nonce, remote pub key, and remote ephemeral pub keys
* Send an ack message in response to that
* Finish up tests for the handshake