### PR TITLE
rlp: remove too many bytes error

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -106,9 +106,8 @@ func decodeLength(t byte, input []byte) (int, int) {
 }
 
 var (
-	errNoBytes      = errors.New("input has no bytes")
-	errTooManyBytes = errors.New("input has more bytes than specified by outermost header")
-	errTooFewBytes  = errors.New("input has fewer bytes than specified by header")
+	errNoBytes     = errors.New("input has no bytes")
+	errTooFewBytes = errors.New("input has fewer bytes than specified by header")
 )
 
 func Decode(input []byte) (Item, error) {

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -117,26 +117,17 @@ func Decode(input []byte) (Item, error) {
 	}
 	switch {
 	case input[0] <= str1H:
-		if len(input) > 1 {
-			return Item{}, errTooManyBytes
-		}
 		return Item{d: []byte{input[0]}}, nil
 	case input[0] <= str55H:
 		i, n := 1, int(input[0]-str55L)
-		switch {
-		case len(input) < i+n:
+		if len(input) < i+n {
 			return Item{}, errTooFewBytes
-		case len(input) > i+n:
-			return Item{}, errTooManyBytes
 		}
 		return Item{d: input[i : i+n]}, nil
 	case input[0] <= strNH:
 		i, n := decodeLength(str55H, input)
-		switch {
-		case len(input) < i+n:
+		if len(input) < i+n {
 			return Item{}, errTooFewBytes
-		case len(input) > i+n:
-			return Item{}, errTooManyBytes
 		}
 		return Item{d: input[i : i+n]}, nil
 	default:
@@ -157,10 +148,15 @@ func Decode(input []byte) (Item, error) {
 		}
 
 		switch {
-		case len(input[i:]) > listSize:
-			return Item{}, errTooManyBytes
 		case len(input[i:]) < listSize:
 			return Item{}, errTooFewBytes
+		case len(input[i:]) > listSize:
+			// It's possible that the input contains
+			// more bytes that is specified by the
+			// header's length. In this case, instead
+			// of returning an error, we simply remove
+			// the extra bytes.
+			input = input[i : i+listSize]
 		}
 
 		item := Item{l: []Item{}}

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -3,7 +3,6 @@ package rlp
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"reflect"
@@ -58,12 +57,6 @@ func BenchmarkEncode(b *testing.B) {
 	}
 }
 
-func intTo2b(i uint16) []byte {
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, i)
-	return b
-}
-
 func randBytes(n int) []byte {
 	res := make([]byte, n)
 	rand.Read(res)
@@ -80,17 +73,6 @@ func TestDecode_Errors(t *testing.T) {
 			"short string no error",
 			[]byte{byte(1)},
 			nil,
-		},
-		{
-			"long string. too many bytes",
-			append(
-				[]byte{
-					byte(str55H + 1),
-					byte(56),
-				},
-				randBytes(57)...,
-			),
-			errTooManyBytes,
 		},
 		{
 			"long string. too few bytes",

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/indexsupply/x/tc"
 )
 
 func ExampleEncode() {
@@ -61,6 +63,18 @@ func randBytes(n int) []byte {
 	res := make([]byte, n)
 	rand.Read(res)
 	return res
+}
+
+func TestDecode_Padding(t *testing.T) {
+	exp := []byte{0x01, 0x00}
+	b := Encode(Bytes(exp))
+	i, err := Decode(append(b, exp...))
+	tc.NoErr(t, err)
+	got, err := i.Bytes()
+	tc.NoErr(t, err)
+	if !bytes.Equal(exp, got) {
+		t.Errorf("expected: %x got: %x", exp, got)
+	}
 }
 
 func TestDecode_Errors(t *testing.T) {


### PR DESCRIPTION
In the case that the input to Decode contains more bytes than is specified by the RLP header, we simply ignore those bytes instead of returning an error.

This is motivated by the fact that the RLPx protocol will add padding around an RLP message. To complicate matters, the padding is random -making it difficult to remove the padding prior to calling rlp.Decode. Therefore, it seems fine and good to have Decode simply ignore trailing data.

This commit also removes an unused test helper function.