### PR TITLE
rlp: improve padded list test

### DIFF
--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -67,10 +67,10 @@ func randBytes(n int) []byte {
 
 func TestDecode_Padding(t *testing.T) {
 	exp := []byte{0x01, 0x00}
-	b := Encode(Bytes(exp))
+	b := Encode(List(Bytes(exp)))
 	i, err := Decode(append(b, exp...))
 	tc.NoErr(t, err)
-	got, err := i.Bytes()
+	got, err := i.At(0).Bytes()
 	tc.NoErr(t, err)
 	if !bytes.Equal(exp, got) {
 		t.Errorf("expected: %x got: %x", exp, got)


### PR DESCRIPTION
The previous test didn't exercise the following code:

        switch {
        case len(input[i:]) < listSize:
            return Item{}, errTooFewBytes
        case len(input[i:]) > listSize:
            // It's possible that the input contains
            // more bytes that is specified by the
            // header's length. In this case, instead
            // of returning an error, we simply remove
            // the extra bytes.
            input = input[:i+listSize]
        }

Now it does.