### PR TITLE
rlpx: parse disconnect message and fix msgID bug

### DIFF
--- a/cmd/xnode/main.go
+++ b/cmd/xnode/main.go
@@ -106,7 +106,6 @@ func main() {
 	hs := rlpx.Initiator(self.PrivateKey, remote.PublicKey)
 	rw := errRW{c: conn}
 	rw.Write(hs.Auth)
-	check(rw.err)
 	rw.Read(hs.HandleAck)
 	check(rw.err)
 
@@ -115,7 +114,6 @@ func main() {
 	rs.Verbose = true
 
 	rw.Write(rs.Hello)
-	check(rw.err)
 	rw.Read(rs.HandleMessage)
 	check(rw.err)
 }

--- a/cmd/xnode/main.go
+++ b/cmd/xnode/main.go
@@ -55,7 +55,7 @@ func serve(c net.Conn, node *enr.Record) {
 	rw.Write(hs.Ack)
 	rs, err := rlpx.Session(node, hs)
 	check(err)
-	rw.Read(rs.HandleHello)
+	rw.Read(rs.HandleMessage)
 	rw.Write(rs.Hello)
 	if rw.err != nil {
 		fmt.Printf("serve-error: %s\n", rw.err)
@@ -106,6 +106,7 @@ func main() {
 	hs := rlpx.Initiator(self.PrivateKey, remote.PublicKey)
 	rw := errRW{c: conn}
 	rw.Write(hs.Auth)
+	check(rw.err)
 	rw.Read(hs.HandleAck)
 	check(rw.err)
 
@@ -114,6 +115,7 @@ func main() {
 	rs.Verbose = true
 
 	rw.Write(rs.Hello)
-	rw.Read(rs.HandleHello)
+	check(rw.err)
+	rw.Read(rs.HandleMessage)
 	check(rw.err)
 }

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -163,6 +163,28 @@ func TestDecodeLength(t *testing.T) {
 	}
 }
 
+func TestDecodeZero(t *testing.T) {
+	b := []byte{0x80}
+	item, err := Decode(b)
+	if err != nil {
+		t.Errorf("error %s", err)
+	}
+	got16, err := item.Uint16()
+	if err != nil {
+		t.Errorf("error %s", err)
+	}
+	if got16 != 0 {
+		t.Errorf("got %d, wanted 0", got16)
+	}
+	got64, err := item.Uint64()
+	if err != nil {
+		t.Errorf("error %s", err)
+	}
+	if got64 != 0 {
+		t.Errorf("got %d, wanted 0", got64)
+	}
+}
+
 func TestDecode(t *testing.T) {
 	cases := []struct {
 		desc string

--- a/rlp/types.go
+++ b/rlp/types.go
@@ -34,9 +34,6 @@ func Uint16(n uint16) Item {
 }
 
 func (i Item) Uint16() (uint16, error) {
-	if len(i.d) == 0 {
-		return 0, errNoData
-	}
 	return binary.BigEndian.Uint16(leftPad(i.d, 2)), nil
 }
 
@@ -45,9 +42,6 @@ func Uint64(n uint64) Item {
 }
 
 func (i Item) Uint64() (uint64, error) {
-	if len(i.d) == 0 {
-		return 0, errNoData
-	}
 	return binary.BigEndian.Uint64(leftPad(i.d, 8)), nil
 }
 


### PR DESCRIPTION
This PR adds a `HandleMessage` method which delegates to the correct handler depending on the `msgId`. It also fixes a bug: we weren't parsing `msgId` correctly before since it's an "RLP-encoded uint64" (so really, the byte `0x80` or [128] should be interpreted as `0` which is the msgId for `Hello`.