### PR TITLE
rlp: refactor. remove unused errors. use bint for decoding

### DIFF
--- a/discv4/discover.go
+++ b/discv4/discover.go
@@ -143,10 +143,7 @@ func (p process) handleENRRequest(req *enr.Record, packet []byte) error {
 	if err != nil {
 		return err
 	}
-	expiration, err := item.At(0).Time()
-	if err != nil {
-		return err
-	}
+	expiration := item.At(0).Time()
 	if expiration.Before(time.Now()) {
 		return errors.New("expired enr request")
 	}
@@ -167,12 +164,8 @@ func (p process) handleFindNode(req *enr.Record, packet []byte) error {
 	if err != nil {
 		return err
 	}
-	target, err := item.At(0).Bytes()
-	if err != nil {
-		return err
-	}
 	var (
-		recs  = p.ktable.FindClosest(isxhash.Keccak32(target), 16)
+		recs  = p.ktable.FindClosest(isxhash.Keccak32(item.At(0).Bytes()), 16)
 		nodes []rlp.Item
 	)
 	for _, rec := range recs {
@@ -213,8 +206,8 @@ func (p process) handleNeighbors(req *enr.Record, packet []byte) error {
 		if err != nil {
 			return err
 		}
-		rec.UdpPort, _ = node.At(1).Uint16()
-		rec.TcpPort, _ = node.At(2).Uint16()
+		rec.UdpPort = node.At(1).Uint16()
+		rec.TcpPort = node.At(2).Uint16()
 		rec.PublicKey, err = node.At(3).Secp256k1PublicKey()
 		if err != nil {
 			return isxerrors.Errorf("reading pubkey: %w", err)
@@ -255,10 +248,7 @@ func (p process) handlePing(req *enr.Record, packet []byte) error {
 	if !reqFrom.Equal(req.Ip) {
 		return errors.New("packet ip address doesn't match udp")
 	}
-	reqFromPort, err := item.At(1).At(1).Uint16()
-	if err != nil {
-		return errors.New("malformed ping from-port data")
-	}
+	reqFromPort := item.At(1).At(1).Uint16()
 	if reqFromPort != req.UdpPort {
 		return errors.New("mismatch ping from-port with udp packet")
 	}

--- a/enr/enr.go
+++ b/enr/enr.go
@@ -127,27 +127,18 @@ func UnmarshalText(str string) (Record, error) {
 }
 
 func decode(item rlp.Item) (Record, error) {
-	var (
-		rec = Record{}
-		err error
-	)
-	rec.Signature, err = item.At(0).Bytes()
-	if err != nil {
+	var rec = Record{}
+	rec.Sequence = item.At(1).Uint64()
+	rec.Signature = item.At(0).Bytes()
+	if len(rec.Signature) == 0 {
 		return Record{}, errors.New("missing signature")
-	}
-	rec.Sequence, err = item.At(1).Uint64()
-	if err != nil {
-		return Record{}, errors.New("missing sequence")
 	}
 
 	for i := 2; i < len(item.List()); i += 2 {
-		k, _ := item.At(i).String()
-		switch k {
+		var err error
+		switch k := item.At(i).String(); k {
 		case "id":
-			rec.IDScheme, err = item.At(i + 1).String()
-			if err != nil {
-				return rec, err
-			}
+			rec.IDScheme = item.At(i + 1).String()
 			if len(rec.IDScheme) == 0 {
 				return rec, errors.New("missing id scheme eg v4")
 			}
@@ -167,25 +158,13 @@ func decode(item rlp.Item) (Record, error) {
 				return rec, err
 			}
 		case "tcp":
-			rec.TcpPort, err = item.At(i + 1).Uint16()
-			if err != nil {
-				return rec, err
-			}
+			rec.TcpPort = item.At(i + 1).Uint16()
 		case "udp":
-			rec.UdpPort, err = item.At(i + 1).Uint16()
-			if err != nil {
-				return rec, err
-			}
+			rec.UdpPort = item.At(i + 1).Uint16()
 		case "tcp6":
-			rec.Tcp6Port, err = item.At(i + 1).Uint16()
-			if err != nil {
-				return rec, err
-			}
+			rec.Tcp6Port = item.At(i + 1).Uint16()
 		case "udp6":
-			rec.Udp6Port, err = item.At(i + 1).Uint16()
-			if err != nil {
-				return rec, err
-			}
+			rec.Udp6Port = item.At(i + 1).Uint16()
 		}
 	}
 

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -19,9 +19,9 @@ func ExampleEncode() {
 	item, _ = Decode(Encode(item))
 
 	var (
-		first, _  = item.At(0).String()
-		second, _ = item.At(1).At(0).String()
-		third, _  = item.At(1).At(1).String()
+		first  = item.At(0).String()
+		second = item.At(1).At(0).String()
+		third  = item.At(1).At(1).String()
 	)
 	fmt.Println(first, second, third)
 
@@ -70,8 +70,7 @@ func TestDecode_Padding(t *testing.T) {
 	b := Encode(List(Bytes(exp)))
 	i, err := Decode(append(b, exp...))
 	tc.NoErr(t, err)
-	got, err := i.At(0).Bytes()
-	tc.NoErr(t, err)
+	got := i.At(0).Bytes()
 	if !bytes.Equal(exp, got) {
 		t.Errorf("expected: %x got: %x", exp, got)
 	}
@@ -164,24 +163,13 @@ func TestDecodeLength(t *testing.T) {
 }
 
 func TestDecodeZero(t *testing.T) {
-	b := []byte{0x80}
-	item, err := Decode(b)
-	if err != nil {
-		t.Errorf("error %s", err)
+	item, err := Decode([]byte{0x80})
+	tc.NoErr(t, err)
+	if item.Uint16() != 0 {
+		t.Errorf("want: 0 got: %d", item.Uint16())
 	}
-	got16, err := item.Uint16()
-	if err != nil {
-		t.Errorf("error %s", err)
-	}
-	if got16 != 0 {
-		t.Errorf("got %d, wanted 0", got16)
-	}
-	got64, err := item.Uint64()
-	if err != nil {
-		t.Errorf("error %s", err)
-	}
-	if got64 != 0 {
-		t.Errorf("got %d, wanted 0", got64)
+	if item.Uint64() != 0 {
+		t.Errorf("want: 0 got: %d", item.Uint64())
 	}
 }
 

--- a/rlp/types.go
+++ b/rlp/types.go
@@ -1,7 +1,6 @@
 package rlp
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -22,51 +21,40 @@ func Bytes(b []byte) Item {
 	return Item{d: b}
 }
 
-func (i Item) Bytes() ([]byte, error) {
-	if len(i.d) == 0 {
-		return nil, errNoData
-	}
-	return i.d, nil
+func (i Item) Bytes() []byte {
+	return i.d
 }
 
 func Uint16(n uint16) Item {
 	return Item{d: bint.Encode(nil, uint64(n))}
 }
 
-func (i Item) Uint16() (uint16, error) {
-	return binary.BigEndian.Uint16(leftPad(i.d, 2)), nil
+func (i Item) Uint16() uint16 {
+	return uint16(bint.Decode(i.d))
 }
 
 func Uint64(n uint64) Item {
 	return Item{d: bint.Encode(nil, n)}
 }
 
-func (i Item) Uint64() (uint64, error) {
-	return binary.BigEndian.Uint64(leftPad(i.d, 8)), nil
+func (i Item) Uint64() uint64 {
+	return bint.Decode(i.d)
 }
 
 func String(s string) Item {
 	return Item{d: []byte(s)}
 }
 
-func (i Item) String() (string, error) {
-	if len(i.d) == 0 {
-		return "", errNoData
-	}
-	return string(i.d), nil
+func (i Item) String() string {
+	return string(i.d)
 }
 
 func Time(t time.Time) Item {
 	return Uint64(uint64(t.Unix()))
 }
 
-func (i Item) Time() (time.Time, error) {
-	var t time.Time
-	ts, err := i.Uint64()
-	if err != nil {
-		return t, err
-	}
-	return time.Unix(int64(ts), 0), nil
+func (i Item) Time() time.Time {
+	return time.Unix(int64(i.Uint64()), 0)
 }
 
 // Uncompressed secpk256k1 public key
@@ -138,16 +126,4 @@ func Byte(b byte) Item {
 
 func Int(n int) Item {
 	return Item{d: bint.Encode(nil, uint64(n))}
-}
-
-// left pads the provided byte array to the wantedLength, in bytes, using 0s.
-// does nothing if b is already at the wanted length.
-func leftPad(b []byte, wantedLength int) []byte {
-	if len(b) >= wantedLength {
-		return b
-	}
-	padded := make([]byte, wantedLength)
-	bytesNeeded := wantedLength - len(b)
-	copy(padded[bytesNeeded:], b)
-	return padded
 }


### PR DESCRIPTION
bint encoding/decoding: we introduced the bint package after 
adding the rlp package. This commits moves the rlp package 
towards the bint package which eliminates the need for padding.

unused errors: it seems better to not return errors for things 
that have good zero values. Instead, callers can check the 
length of a string or byte slice.