### PR TITLE
rlpx: handle Eth protocol Status message

### DIFF
--- a/cmd/xnode/main.go
+++ b/cmd/xnode/main.go
@@ -116,4 +116,8 @@ func main() {
 	rw.Write(rs.Hello)
 	rw.Read(rs.HandleMessage)
 	check(rw.err)
+
+	// Read the Eth protocol message from geth
+	rw.Read(rs.HandleMessage)
+	check(rw.err)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )
 
-require golang.org/x/sys v0.1.0 // indirect
+require (
+	github.com/golang/snappy v0.0.4 // indirect
+	golang.org/x/sys v0.1.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=


### PR DESCRIPTION
Once the `Hello` handshake has been established, the Geth code will send a Status message under the Eth/67 sub protocol if our node declares that it supports the Eth capability. This PR adds a handler to parse this message by implementing snappy decompression and logging the Status message.