### PR TITLE
rlpx: refactor encode/decode snappy

### DIFF
--- a/cmd/xnode/main.go
+++ b/cmd/xnode/main.go
@@ -115,9 +115,6 @@ func main() {
 
 	rw.Write(rs.Hello)
 	rw.Read(rs.HandleMessage)
-	check(rw.err)
-
-	// Read the Eth protocol message from geth
 	rw.Write(rs.EthStatus)
 	rw.Read(rs.HandleMessage)
 	check(rw.err)

--- a/rlpx/rlpx_test.go
+++ b/rlpx/rlpx_test.go
@@ -75,8 +75,11 @@ func TestSession(t *testing.T) {
 	s2, err := Session(n2, h2)
 	tc.NoErr(t, err)
 
-	b1, _ := s1.Hello()
-	tc.NoErr(t, s2.HandleMessage(b1))
+	m1, _ := s1.Hello()
+	tc.NoErr(t, s2.HandleMessage(m1))
+
+	m2, _ := s1.EthStatus()
+	tc.NoErr(t, s2.HandleMessage(m2))
 }
 
 func prv(t *testing.T) *secp256k1.PrivateKey {


### PR DESCRIPTION
Since compression is omitted only for the Hello message, 
I wanted to have the conditional logic alongside the Hello 
implementation instead of having it in the encode/decode path.

Also, goimports cleaned up some whitespace and ordering.

Finally, I added a quick test for the status message.