### PR TITLE
abi: add function for parsing event logs. s/at/abit

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -1,18 +1,129 @@
-// ABI encoding and decoding.
-// Does not support packed encoding.
-// Implementation based on:
-// https://docs.soliditylang.org/en/latest/abi-spec.html
+// ABI encoding/decoding with log parsing
+//
+// Implementation based on the [ABI Spec].
+//
+// [ABI Spec]: https://docs.soliditylang.org/en/latest/abi-spec.html
 package abi
 
 import (
 	"math/big"
+	"strings"
 
-	"github.com/indexsupply/x/abi/at"
+	"github.com/indexsupply/x/abi/abit"
 	"github.com/indexsupply/x/bint"
+	"github.com/indexsupply/x/isxhash"
 )
 
+type Input struct {
+	Name    string
+	Type    abit.Type
+	Indexed bool
+}
+
+type Event struct {
+	sig     string
+	sigHash [32]byte
+
+	Name      string
+	Type      string
+	Anonymous bool
+	Inputs    []Input
+}
+
+// Retruns new [Event] setting Name.
+func NamedEvent(name string) *Event {
+	return &Event{Name: name}
+}
+
+// Adds indexed input to e and returns e for successive calling
+func (e *Event) Indexed(name string, t abit.Type) *Event {
+	e.Inputs = append(e.Inputs, Input{
+		Name:    name,
+		Type:    t,
+		Indexed: true,
+	})
+	return e
+}
+
+// Adds un-indexed input to e and returns e for successive calling
+func (e *Event) UnIndexed(name string, t abit.Type) *Event {
+	e.Inputs = append(e.Inputs, Input{
+		Name:    name,
+		Type:    t,
+		Indexed: false,
+	})
+	return e
+}
+
+// Computes signature (eg name(type1,type2)). Caches result on e
+func (e *Event) Signature() string {
+	if e.sig != "" {
+		return e.sig
+	}
+	var s strings.Builder
+	s.WriteString(e.Name)
+	s.WriteString("(")
+	for i := range e.Inputs {
+		s.WriteString(e.Inputs[i].Type.Name)
+		if i+1 < len(e.Inputs) {
+			s.WriteString(",")
+		}
+	}
+	s.WriteString(")")
+	e.sig = s.String()
+	return e.sig
+}
+
+// Computes keccak hash over [Event.Signature]. Caches result on e
+func (e *Event) SignatureHash() [32]byte {
+	if e.sigHash != [32]byte{} {
+		return e.sigHash
+	}
+	e.sigHash = isxhash.Keccak32([]byte(e.Signature()))
+	return e.sigHash
+}
+
+type Log struct {
+	Address [20]byte
+	Topics  [4][32]byte
+	Data    []byte
+}
+
+// Matches event data in a log. Returns a map with input names for keys
+// and [Item] for types.
+//
+// A false return value indicates the first log topic doesn't match
+// the event's [Event.SignatureHash].
+func Match(l Log, e *Event) (map[string]Item, bool) {
+	if e.SignatureHash() != l.Topics[0] {
+		return nil, false
+	}
+
+	var (
+		items     = map[string]Item{}
+		unindexed []Input
+	)
+	for i, input := range e.Inputs {
+		if !input.Indexed {
+			unindexed = append(unindexed, input)
+			continue
+		}
+		items[input.Name] = Bytes(l.Topics[i+1][:])
+	}
+
+	var types []abit.Type
+	for _, input := range unindexed {
+		types = append(types, input.Type)
+	}
+	item := Decode(l.Data, abit.Tuple(types...))
+	for i, input := range unindexed {
+		items[input.Name] = item.At(i)
+	}
+	return items, true
+}
+
 type Item struct {
-	at.Type
+	abit.Type
 
 	// must be d XOR l
 	d []byte
@@ -20,15 +131,22 @@ type Item struct {
 }
 
 func Bytes(d []byte) Item {
-	return Item{Type: at.Bytes, d: d}
+	return Item{Type: abit.Bytes, d: d}
 }
 
 func (it Item) Bytes() []byte {
 	return it.d
 }
 
+func (it Item) Address() [20]byte {
+	if len(it.d) < 32 {
+		return [20]byte{}
+	}
+	return *(*[20]byte)(it.d[12:])
+}
+
 func String(s string) Item {
-	return Item{Type: at.String, d: []byte(s)}
+	return Item{Type: abit.String, d: []byte(s)}
 }
 
 func (it Item) String() string {
@@ -40,7 +158,7 @@ func Bool(b bool) Item {
 	if b {
 		d[31] = 1
 	}
-	return Item{Type: at.Bool, d: d[:]}
+	return Item{Type: abit.Bool, d: d[:]}
 }
 
 func (it Item) Bool() bool {
@@ -54,7 +172,7 @@ func BigInt(i *big.Int) Item {
 	var b [32]byte
 	i.FillBytes(b[:])
 	return Item{
-		Type: at.Uint256,
+		Type: abit.Uint256,
 		d:    b[:],
 	}
 }
@@ -65,10 +183,18 @@ func (it Item) BigInt() *big.Int {
 	return x
 }
 
+func (it Item) BigIntSlice() []*big.Int {
+	var res []*big.Int
+	for i := range it.l {
+		res = append(res, it.l[i].BigInt())
+	}
+	return res
+}
+
 func Uint64(i uint64) Item {
 	var b [32]byte
 	bint.Encode(b[:], i)
-	return Item{Type: at.Uint64, d: b[:]}
+	return Item{Type: abit.Uint64, d: b[:]}
 }
 
 func (it Item) Uint64() uint64 {
@@ -77,7 +203,7 @@ func (it Item) Uint64() uint64 {
 
 func List(items ...Item) Item {
 	return Item{
-		Type: at.List(items[0].Type),
+		Type: abit.List(items[0].Type),
 		l:    items,
 	}
 }
@@ -89,17 +215,22 @@ func (it Item) At(i int) Item {
 	return it.l[i]
 }
 
+// Returns length of list, tuple, or bytes depending
+// on how the item was constructed.
 func (it Item) Len() int {
-	return len(it.l)
+	if len(it.l) > 0 {
+		return len(it.l)
+	}
+	return len(it.d)
 }
 
 func Tuple(items ...Item) Item {
-	var types []at.Type
+	var types []abit.Type
 	for i := range items {
 		types = append(types, items[i].Type)
 	}
 	return Item{
-		Type: at.Tuple(types...),
+		Type: abit.Tuple(types...),
 		l:    items,
 	}
 }
@@ -112,23 +243,24 @@ func rpad(l int, d []byte) []byte {
 	return append(d, make([]byte, l-n)...)
 }
 
+// ABI encoding. Not packed.
 func Encode(it Item) []byte {
 	switch it.Kind {
-	case at.S:
+	case abit.S:
 		return it.d
-	case at.D:
+	case abit.D:
 		var c [32]byte
 		bint.Encode(c[:], uint64(len(it.d)))
 		return append(c[:], rpad(32, it.d)...)
-	case at.L:
+	case abit.L:
 		var c [32]byte
 		bint.Encode(c[:], uint64(len(it.l)))
 		return append(c[:], Encode(Tuple(it.l...))...)
-	case at.T:
+	case abit.T:
 		var head, tail []byte
 		for i := range it.l {
 			switch it.l[i].Kind {
-			case at.S:
+			case abit.S:
 				head = append(head, Encode(it.l[i])...)
 			default:
 				var offset [32]byte
@@ -143,33 +275,36 @@ func Encode(it Item) []byte {
 	}
 }
 
-func Decode(input []byte, t at.Type) Item {
+// Decodes ABI encoded bytes into an [Item] according to
+// the 'schema' defined by t. For example:
+//	Decode(b, abit.Tuple(abit.String, abit.Uint256))
+func Decode(input []byte, t abit.Type) Item {
 	switch t.Kind {
-	case at.S:
+	case abit.S:
 		return Item{Type: t, d: input[:32]}
-	case at.D:
+	case abit.D:
 		count := bint.Decode(input[:32])
 		return Item{Type: t, d: input[32 : 32+count]}
-	case at.L:
+	case abit.L:
 		count := bint.Decode(input[:32])
 		items := make([]Item, count)
 		for i := uint64(0); i < count; i++ {
 			n := 32 + (32 * i) //skip count (head)
 			switch t.ElementType.Kind {
-			case at.S:
+			case abit.S:
 				items[i] = Decode(input[n:], *t.ElementType)
 			default:
-				tail := 32 + bint.Decode(input[n:n+32])
-				items[i] = Decode(input[tail:], *t.ElementType)
+				offset := 32 + bint.Decode(input[n:n+32])
+				items[i] = Decode(input[offset:], *t.ElementType)
 			}
 		}
 		return List(items...)
-	case at.T:
+	case abit.T:
 		items := make([]Item, len(t.Fields))
 		for i, f := range t.Fields {
 			n := 32 * i
 			switch f.Kind {
-			case at.S:
+			case abit.S:
 				items[i] = Decode(input[n:n+32], *f)
 			default:
 				offset := bint.Decode(input[n : n+32])

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/indexsupply/x/abi/at"
+	"github.com/indexsupply/x/abi/abit"
 	"github.com/indexsupply/x/tc"
 )
 
@@ -79,57 +79,63 @@ func TestDecode(t *testing.T) {
 	cases := []struct {
 		desc string
 		want Item
-		t    at.Type
+		t    abit.Type
 	}{
 		{
 			desc: "1 static",
 			want: Uint64(0),
-			t:    at.Uint64,
+			t:    abit.Uint64,
 		},
 		{
 			desc: "N static",
 			want: Tuple(Uint64(0), Uint64(1)),
-			t:    at.Tuple(at.Uint64, at.Uint64),
+			t:    abit.Tuple(abit.Uint64, abit.Uint64),
 		},
 		{
 			desc: "1 dynamic",
 			want: String("hello world"),
-			t:    at.String,
+			t:    abit.String,
 		},
 		{
 			desc: "N dynamic",
 			want: Tuple(String("hello"), String("world")),
-			t:    at.Tuple(at.String, at.String),
+			t:    abit.Tuple(abit.String, abit.String),
 		},
 		{
 			desc: "list static",
 			want: List(Uint64(0), Uint64(1)),
-			t:    at.List(at.Uint64),
+			t:    abit.List(abit.Uint64),
 		},
 		{
 			desc: "list dynamic",
 			want: List(String("hello"), String("world")),
-			t:    at.List(at.String),
+			t:    abit.List(abit.String),
 		},
 		{
 			desc: "tuple static",
 			want: Tuple(Uint64(0)),
-			t:    at.Tuple(at.Uint64),
+			t:    abit.Tuple(abit.Uint64),
 		},
 		{
 			desc: "tuple static and dynamic",
 			want: Tuple(Uint64(0), String("hello")),
-			t:    at.Tuple(at.Uint64, at.String),
+			t:    abit.Tuple(abit.Uint64, abit.String),
 		},
 		{
 			desc: "tuple tuple",
 			want: Tuple(Uint64(0), Tuple(String("hello"))),
-			t:    at.Tuple(at.Uint64, at.Tuple(at.String)),
+			t:    abit.Tuple(abit.Uint64, abit.Tuple(abit.String)),
 		},
 		{
 			desc: "tuple tuple list",
 			want: Tuple(Uint64(0), Tuple(String("hello")), List(Uint64(1))),
-			t:    at.Tuple(at.Uint64, at.Tuple(at.String), at.List(at.Uint64)),
+			t: abit.Tuple(
+				abit.Uint64,
+				abit.Tuple(
+					abit.String,
+				),
+				abit.List(abit.Uint64),
+			),
 		},
 	}
 	for _, c := range cases {

--- a/abi/abit/types.go
+++ b/abi/abit/types.go
@@ -1,12 +1,13 @@
-package at
+// Types for ABI encoding / decoding
+package abit
 
 type kind byte
 
 const (
-	S kind = iota
-	D
-	T
-	L
+	S kind = iota //static
+	D             //dynamic
+	T             //tuple
+	L             //list
 )
 
 type Type struct {
@@ -30,13 +31,13 @@ var (
 		Name: "bytes",
 		Kind: D,
 	}
-	Uint64 = Type{
-		Name: "uint64",
-		Kind: S,
-	}
 	String = Type{
 		Name: "string",
 		Kind: D,
+	}
+	Uint64 = Type{
+		Name: "uint64",
+		Kind: S,
 	}
 	Uint256 = Type{
 		Name: "uint256",
@@ -47,7 +48,7 @@ var (
 func List(et Type) Type {
 	return Type{
 		ElementType: &et,
-		Name:        "list",
+		Name:        et.Name + "[]",
 		Kind:        L,
 	}
 }


### PR DESCRIPTION
Uses the abi encoding functionality to parse emitted events from evm logs.

Indexed logs are easy to parse as they are contained in the topics array. However, un-indexed
logs are abi-encoded bytes in the log's data field. The data field needs to be decoded with a
user-supplied schema. The `abit` package can be used to define the decoding schema.

Example:

    bxfr, ok := xabi.Match(log, abi.NamedEvent("TransferBatch").
        Indexed("operator", abit.Address).
        Indexed("from", abit.Address).
        Indexed("to", abit.Address).
        UnIndexed("ids", abit.List(abit.Uint256)).
        UnIndexed("values", abit.List(abit.Uint256)),
    )