### PR TITLE
abi/abit: add abi sig support for type names

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -64,7 +64,7 @@ func (e *Event) Signature() string {
 	s.WriteString(e.Name)
 	s.WriteString("(")
 	for i := range e.Inputs {
-		s.WriteString(e.Inputs[i].Type.Name)
+		s.WriteString(e.Inputs[i].Type.Name())
 		if i+1 < len(e.Inputs) {
 			s.WriteString(",")
 		}

--- a/abi/abit/types_test.go
+++ b/abi/abit/types_test.go
@@ -1,0 +1,32 @@
+package abit
+
+import "testing"
+
+func TestName(t *testing.T) {
+	cases := []struct {
+		t    Type
+		want string
+	}{
+		{
+			t:    Address,
+			want: "address",
+		},
+		{
+			t:    Tuple(Address, Uint256),
+			want: "(address,uint256)",
+		},
+		{
+			t:    List(Tuple(Address, Uint256)),
+			want: "(address,uint256)[]",
+		},
+		{
+			t:    List(Address),
+			want: "address[]",
+		},
+	}
+	for _, tc := range cases {
+		if tc.t.Name() != tc.want {
+			t.Errorf("got: %s want: %s", tc.t.Name(), tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Event signatures can contain tuples, a list of tupes, tuples of tuples, 
etc... The Name() method now makes it easy to generate the name
for a type that is ready for ABI signatures.