### PR TITLE
abi: build type schema from Event/Input structs

### DIFF
--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -11,6 +11,75 @@ import (
 	"github.com/indexsupply/x/tc"
 )
 
+func TestABIType(t *testing.T) {
+	cases := []struct {
+		input Input
+		want  abit.Type
+	}{
+		{
+			input: Input{
+				Name: "a",
+				Type: "uint8",
+			},
+			want: abit.Uint8,
+		},
+		{
+			input: Input{
+				Name: "a",
+				Type: "uint8[]",
+			},
+			want: abit.List(abit.Uint8),
+		},
+		{
+			input: Input{
+				Name: "a",
+				Type: "tuple",
+				Components: []Input{
+					Input{
+						Name: "b",
+						Type: "uint8",
+					},
+				},
+			},
+			want: abit.Tuple(abit.Uint8),
+		},
+		{
+			input: Input{
+				Name: "a",
+				Type: "tuple[][]",
+				Components: []Input{
+					Input{
+						Name: "b",
+						Type: "uint8",
+					},
+					Input{
+						Name: "c",
+						Type: "tuple",
+						Components: []Input{
+							Input{
+								Name: "d",
+								Type: "uint8",
+							},
+						},
+					},
+				},
+			},
+			want: abit.List(abit.List(abit.Tuple(
+				abit.Uint8,
+				abit.Tuple(
+					abit.Uint8,
+				),
+			))),
+		},
+	}
+	for _, tc := range cases {
+		got := tc.input.ABIType()
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("got: %s want: %s", got.Name(), tc.want.Name())
+		}
+	}
+}
+
 func TestPad(t *testing.T) {
 	cases := []struct {
 		desc  string

--- a/abi/abit/types.go
+++ b/abi/abit/types.go
@@ -12,6 +12,32 @@ const (
 	L             //list
 )
 
+func Resolve(desc string, fields ...Type) Type {
+	if strings.HasSuffix(desc, "[]") {
+		return List(Resolve(strings.TrimSuffix(desc, "[]"), fields...))
+	}
+	switch desc {
+	case "address":
+		return Address
+	case "bool":
+		return Bool
+	case "bytes":
+		return Bytes
+	case "bytes32":
+		return Bytes32
+	case "tuple":
+		return Tuple(fields...)
+	case "uint8":
+		return Uint8
+	case "uint64":
+		return Uint64
+	case "uint256":
+		return Uint256
+	default:
+		return Type{}
+	}
+}
+
 type Type struct {
 	Kind kind
 	name string
@@ -27,7 +53,7 @@ type Type struct {
 // For example:
 // tuple(uint8, address) becomes (uint8, address)
 // tuple(uint8, address[] becomes (uint8, address)[]
-func (t *Type) Name() string {
+func (t Type) Name() string {
 	switch t.Kind {
 	case L:
 		return t.Elem.Name() + "[]"
@@ -60,9 +86,17 @@ var (
 		name: "bytes",
 		Kind: D,
 	}
+	Bytes32 = Type{
+		name: "bytes32",
+		Kind: S,
+	}
 	String = Type{
 		name: "string",
 		Kind: D,
+	}
+	Uint8 = Type{
+		name: "uint8",
+		Kind: S,
 	}
 	Uint64 = Type{
 		name: "uint64",

--- a/abi/abit/types_test.go
+++ b/abi/abit/types_test.go
@@ -1,6 +1,43 @@
 package abit
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	cases := []struct {
+		desc string
+		want Type
+	}{
+		{
+			desc: "uint8",
+			want: Uint8,
+		},
+		{
+			desc: "uint8[]",
+			want: List(Uint8),
+		},
+		{
+			desc: "uint8[][][]",
+			want: List(List(List(Uint8))),
+		},
+		{
+			desc: "tuple",
+			want: Tuple(),
+		},
+		{
+			desc: "tuple[]",
+			want: List(Tuple()),
+		},
+	}
+	for _, tc := range cases {
+		r := Resolve(tc.desc)
+		if !reflect.DeepEqual(r, tc.want) {
+			t.Errorf("got: %s want: %s", r.Name(), tc.want.Name())
+		}
+	}
+}
 
 func TestName(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
The newly added Input.ABIType and abit.Resolve method/function supports the flow of building Event/Input structs from JSON instead of builder methods. It is still possible to build the structs by hand, but it is likely that the majority of use cases will depend on parsing a ABI JSON file and then using that data to call Match functions. In this case, we needed a method to recursively build the abit.Type schema from the JSON.