### PR TITLE
abi: add uint8 support for encoding/decoding

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -187,6 +187,16 @@ func Uint64(i uint64) Item {
 	return Item{Type: abit.Uint64, d: b[:]}
 }
 
+func Uint8(i uint8) Item {
+	var b [32]byte
+	bint.Encode(b[:], uint64(i))
+	return Item{Type: abit.Uint8, d: b[:]}
+}
+
+func (it Item) Uint8() uint8 {
+	return uint8(bint.Decode(it.d))
+}
+
 func (it Item) Uint64() uint64 {
 	return bint.Decode(it.d)
 }

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -151,6 +151,11 @@ func TestDecode(t *testing.T) {
 		t    abit.Type
 	}{
 		{
+			desc: "1 uint8",
+			want: Uint8(0),
+			t:    abit.Uint8,
+		},
+		{
 			desc: "1 static",
 			want: Uint64(0),
 			t:    abit.Uint64,


### PR DESCRIPTION
not totally sure if this is the right approach (casting the uint8 to a uint64). my understanding is that a uint8 abi encodes the same as a uint64 (mostly from playing around with [this site](https://abi.hashex.org)) but as always, i could be misunderstanding something