### PR TITLE
Nested struct generation example

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -18,6 +18,7 @@ type Input struct {
 	Indexed    bool
 	Name       string
 	Type       string
+	Gtype      string
 	Components []Input
 }
 
@@ -325,6 +326,7 @@ func Encode(it Item) []byte {
 
 // Decodes ABI encoded bytes into an [Item] according to
 // the 'schema' defined by t. For example:
+//
 //	Decode(b, abit.Tuple(abit.String, abit.Uint256))
 func Decode(input []byte, t abit.Type) Item {
 	switch t.Kind {

--- a/abi/nested/nested.go
+++ b/abi/nested/nested.go
@@ -1,0 +1,64 @@
+package nested
+
+import (
+	"math/big"
+
+	"github.com/indexsupply/x/abi"
+)
+
+var e = abi.Event{
+	Name: "e",
+	Type: "event",
+	Inputs: []abi.Input{
+		{
+			Name:    "s",
+			Type:    "tuple",
+			Indexed: false,
+			Components: []abi.Input{
+				{
+					Name:    "a",
+					Type:    "uint256",
+					Gtype:   "*big.Int",
+					Indexed: false,
+				},
+				{
+					Name:    "b",
+					Type:    "uint256",
+					Gtype:   "*big.Int",
+					Indexed: false,
+				},
+				{
+					Name:    "c",
+					Type:    "tuple",
+					Gtype:   "struct",
+					Indexed: false,
+					Components: []abi.Input{
+						{
+							Name:    "x",
+							Indexed: false,
+							Gtype:   "*big.Int",
+							Type:    "uint256",
+						},
+						{
+							Name:    "y",
+							Indexed: false,
+							Gtype:   "*big.Int",
+							Type:    "uint256",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+type E struct {
+	S struct {
+		A *big.Int
+		B *big.Int
+		C struct {
+			X *big.Int
+			Y *big.Int
+		}
+	}
+}

--- a/abi/nested/nested.go
+++ b/abi/nested/nested.go
@@ -36,7 +36,7 @@ var e = abi.Event{
 						{
 							Name:    "x",
 							Indexed: false,
-							Gtype:   "*ig.Int",
+							Gtype:   "*big.Int",
 							Type:    "uint256",
 						},
 						{

--- a/abi/nested/nested.go
+++ b/abi/nested/nested.go
@@ -36,7 +36,7 @@ var e = abi.Event{
 						{
 							Name:    "x",
 							Indexed: false,
-							Gtype:   "*big.Int",
+							Gtype:   "*ig.Int",
 							Type:    "uint256",
 						},
 						{

--- a/abi/nested/template.go
+++ b/abi/nested/template.go
@@ -1,0 +1,51 @@
+package nested
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"strings"
+	"text/template"
+
+	"github.com/indexsupply/x/abi"
+)
+
+const ct = `
+{{with .Event}}
+type {{.Name}} struct {
+	{{range .Inputs}}
+		{{geninput .}}
+	{{end}}
+}
+{{end}}
+`
+
+var funcs = template.FuncMap{"geninput": GenInput}
+
+func GenInput(i abi.Input) string {
+	if i.Type == "tuple" {
+		var c []string
+		for _, comp := range i.Components {
+			c = append(c, GenInput(comp))
+		}
+		return fmt.Sprintf("%s struct{%s}", strings.ToTitle(i.Name), strings.Join(c, "\n"))
+	} else {
+		return fmt.Sprintf("%s %s", strings.ToTitle(i.Name), i.Gtype)
+	}
+}
+
+func Generate() ([]byte, error) {
+	data := struct {
+		Event abi.Event
+	}{
+		Event: e,
+	}
+	var (
+		b bytes.Buffer
+		t = template.Must(template.New("letter").Funcs(funcs).Parse(ct))
+	)
+	if err := t.Execute(&b, data); err != nil {
+		return nil, err
+	}
+	return format.Source(b.Bytes())
+}

--- a/abi/nested/template.go
+++ b/abi/nested/template.go
@@ -12,7 +12,7 @@ import (
 
 const ct = `
 {{with .Event}}
-type {{.Name}} struct {
+type {{titleize .Name}} struct {
 	{{range .Inputs}}
 		{{geninput .}}
 	{{end}}
@@ -20,13 +20,13 @@ type {{.Name}} struct {
 {{end}}
 `
 
-var funcs = template.FuncMap{"geninput": GenInput}
+var funcs = template.FuncMap{"geninput": genInput, "titleize": strings.ToTitle}
 
-func GenInput(i abi.Input) string {
+func genInput(i abi.Input) string {
 	if i.Type == "tuple" {
 		var c []string
 		for _, comp := range i.Components {
-			c = append(c, GenInput(comp))
+			c = append(c, genInput(comp))
 		}
 		return fmt.Sprintf("%s struct{%s}", strings.ToTitle(i.Name), strings.Join(c, "\n"))
 	} else {

--- a/cmd/genabi/main.go
+++ b/cmd/genabi/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/indexsupply/x/abi/nested"
+)
+
+func main() {
+	b, err := nested.Generate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+}


### PR DESCRIPTION
Pretty rough sketch still, but an example of how we'd might want to generate events for those with nested structs. Running `cmd/genabi` gives:

```
type e struct {
	S struct {
		A *big.Int
		B *big.Int
		C struct {
			X *big.Int
			Y *big.Int
		}
	}
}
```