### PR TITLE
abi: refactor. break abi.Match interface

### DIFF
--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -75,7 +75,7 @@ func TestABIType(t *testing.T) {
 	for _, tc := range cases {
 		got := tc.input.ABIType()
 		if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("got: %s want: %s", got.Name(), tc.want.Name())
+			t.Errorf("got: %s want: %s", got.Name, tc.want.Name)
 		}
 	}
 }

--- a/abi/abit/types.go
+++ b/abi/abit/types.go
@@ -42,28 +42,25 @@ func Resolve(desc string, fields ...Type) Type {
 
 type Type struct {
 	Kind kind
-	name string
+	Name string
 
 	Fields []*Type //For Tuple
 	Elem   *Type   //For List
 }
 
-// Returns the name of the type in a format ready for ABI signatures
-// This is achieved by calling abit.Name on tuple abit.Fields and
-// tuple abit.Elem for tuples and arrays respectively.
-//
+// Returns signature of the type including it's Elem and Fields
 // For example:
-// tuple(uint8, address) becomes (uint8, address)
-// tuple(uint8, address[] becomes (uint8, address)[]
-func (t Type) Name() string {
+// 	tuple(uint8, address) becomes (uint8, address)
+// 	tuple(uint8, address[] becomes (uint8, address)[]
+func (t Type) Signature() string {
 	switch t.Kind {
 	case L:
-		return t.Elem.Name() + "[]"
+		return t.Elem.Signature() + "[]"
 	case T:
 		var s strings.Builder
 		s.WriteString("(")
 		for i, f := range t.Fields {
-			s.WriteString(f.Name())
+			s.WriteString(f.Signature())
 			if i+1 < len(t.Fields) {
 				s.WriteString(",")
 			}
@@ -71,51 +68,55 @@ func (t Type) Name() string {
 		s.WriteString(")")
 		return s.String()
 	default:
-		return t.name
+		return t.Name
 	}
 }
 
 var (
 	Address = Type{
-		name: "address",
+		Name: "address",
 		Kind: S,
 	}
 	Bool = Type{
-		name: "bool",
+		Name: "bool",
 		Kind: S,
 	}
 	Bytes = Type{
-		name: "bytes",
+		Name: "bytes",
 		Kind: D,
 	}
 	Bytes32 = Type{
-		name: "bytes32",
+		Name: "bytes32",
 		Kind: S,
 	}
 	String = Type{
-		name: "string",
+		Name: "string",
 		Kind: D,
 	}
 	Uint8 = Type{
-		name: "uint8",
+		Name: "uint8",
 		Kind: S,
 	}
 	Uint64 = Type{
-		name: "uint64",
+		Name: "uint64",
 		Kind: S,
 	}
 	Uint256 = Type{
-		name: "uint256",
+		Name: "uint256",
 		Kind: S,
 	}
 )
 
 func List(et Type) Type {
-	return Type{Kind: L, Elem: &et}
+	return Type{
+		Name: et.Signature(),
+		Kind: L,
+		Elem: &et,
+	}
 }
 
 func Tuple(types ...Type) Type {
-	t := Type{Kind: T}
+	t := Type{Name: "tuple", Kind: T}
 	for i := range types {
 		t.Fields = append(t.Fields, &types[i])
 	}

--- a/abi/abit/types_test.go
+++ b/abi/abit/types_test.go
@@ -34,7 +34,7 @@ func TestResolve(t *testing.T) {
 	for _, tc := range cases {
 		r := Resolve(tc.desc)
 		if !reflect.DeepEqual(r, tc.want) {
-			t.Errorf("got: %s want: %s", r.Name(), tc.want.Name())
+			t.Errorf("got: %s want: %s", r.Name, tc.want.Name)
 		}
 	}
 }
@@ -62,8 +62,8 @@ func TestName(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		if tc.t.Name() != tc.want {
-			t.Errorf("got: %s want: %s", tc.t.Name(), tc.want)
+		if tc.t.Signature() != tc.want {
+			t.Errorf("got: %s want: %s", tc.t.Signature(), tc.want)
 		}
 	}
 }


### PR DESCRIPTION
In preparation for a new abi code generator, we are going to have Match return a tuple item instead of a map of items. The map of items is inherently flawed since it only does a good job of accessing top level inputs. Events with nested data structures were not name-accessible from the map.

To solve the accessibility problem, we will introduce code generation that will act as a thin layer around the Item so that accessing data doesn't require indexing (eg item.At(XXX) and so forth).