### PR TITLE
bloom: new pkg. Sketch out logs bloom filter for events

### DIFF
--- a/bloom/bloom.go
+++ b/bloom/bloom.go
@@ -1,0 +1,47 @@
+// M3:2048 Bloom filter
+//
+// Useful for reducing a log entry into a single 256-byte hash
+package bloom
+
+/*
+Bloom filter implementation based on the Yello Paper/4.3.1:
+
+	M3:2048 is a specialised Bloom filter that sets three
+	bits out of 2048, given an arbitrary byte sequence. It does
+	this through taking the low-order 11 bits of each of the
+	first three pairs of bytes in a Keccak-256 hash of the byte
+	sequence.
+*/
+type Filter [256]byte
+
+// (32) m(x,i) ≡ KEC(x)[i, i + 1] mod 2048
+func m(x []byte, i int) uint16 {
+	return (uint16(x[0])<<8 | uint16(x[1])) & 0x7ff
+}
+
+// returns byte position [0,255] based on m(x,i)
+func byteIndex(m uint16) uint8 {
+	return uint8((2047 - m) / 8)
+}
+
+// returns bit position [0,8] based on m(x,i)
+func bitIndex(m uint16) uint8 {
+	return uint8(m % 8)
+}
+
+// Returns true if the data isn't in the filter.
+// Returns false when the data might be in the filter.
+func (bf Filter) Missing(d []byte) bool {
+	m1, m2, m3 := m(d, 0), m(d, 2), m(d, 4)
+	b1 := bf[byteIndex(m1)]&(1<<(bitIndex(m1))) == 0
+	b2 := bf[byteIndex(m2)]&(1<<(bitIndex(m2))) == 0
+	b3 := bf[byteIndex(m3)]&(1<<(bitIndex(m3))) == 0
+	return b1 && b2 && b3
+}
+
+func (bf *Filter) Add(d []byte) {
+	m1, m2, m3 := m(d, 0), m(d, 2), m(d, 4)
+	bf[byteIndex(m1)] |= (1 << bitIndex(m1))
+	bf[byteIndex(m2)] |= (1 << bitIndex(m2))
+	bf[byteIndex(m3)] |= (1 << bitIndex(m3))
+}

--- a/bloom/bloom_test.go
+++ b/bloom/bloom_test.go
@@ -1,0 +1,73 @@
+package bloom
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+)
+
+func BenchmarkFilterAdd(b *testing.B) {
+	b.Skip()
+	input := make([][]byte, 1000)
+	for i := 0; i < 1000; i++ {
+		var d [32]byte
+		_, err := rand.Read(d[:])
+		if err != nil {
+			b.Fatal(err)
+		}
+		input[i] = d[:]
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var bf Filter
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1000; j++ {
+			bf.Add(input[j])
+		}
+	}
+}
+
+func BenchmarkFilterMissing(b *testing.B) {
+	var (
+		bf    Filter
+		input [][32]byte
+	)
+	for i := 0; i < 1000; i++ {
+		var d [32]byte
+		_, err := rand.Read(d[:])
+		if err != nil {
+			b.Fatal(err)
+		}
+		bf.Add(d[:])
+		input = append(input, d)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(input); j++ {
+			bf.Missing(input[j][:])
+		}
+	}
+}
+
+func TestFilter(t *testing.T) {
+	var data [32]byte
+	_, err := rand.Read(data[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bf Filter
+	bf.Add(data[:])
+	if bf.Missing(data[:]) {
+		t.Errorf("expected data to exist in bloom filter")
+	}
+}
+
+func TestExistsWithEvent(t *testing.T) {
+	bb, _ := hex.DecodeString("2d209418e80821025f0850088d4d4aae8131728a4025ddb00cdd04a4d4542804101ad388908140ab1449d2182f04554c1370256a8f2b2f6906778941542e201c0cf960f04709a46ead0a9c6b42366bb289e910a8d94d3224164c1c30c81b2b85171004004e4214660046720caa6968d1cd06283b401416435a0404d4b85ac8844700a19a76e2add9a05fb4c40210028b22006f9bc5246409243801c2283434c8db0061d37c28714b22a06f840c10040e724016263d1b214240444ea205c453d04836d103e6710272802c4840440c50461be906402b0c4b54dc1c99aa3080e202d130b32a2d542000c580b74a76c15d8005b2322970cc0e41b1292a34480970a1")
+	sb, _ := hex.DecodeString("b8e138887d0aa13bab447e82de9d5c1777041ecd21ca36ba824ff1e6c07ddda4")
+	bf := Filter(bb)
+	if bf.Missing(sb) {
+		t.Errorf("expected data to exist in bloom filter")
+	}
+}


### PR DESCRIPTION
Implements the special Bloom filter used for log data as described in the [Ethereum Yellowpaper](https://ethereum.github.io/yellowpaper/paper.pdf) (page 10)