### PR TITLE
abi: fix static check for nested static tuples

### DIFF
--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -442,6 +442,29 @@ func TestEncode(t *testing.T) {
 				68656c6c6f000000000000000000000000000000000000000000000000000000
 			`),
 		},
+		{
+			desc:  "nested static tuples",
+			input: Tuple(Tuple(Uint8(42), Uint8(43), Tuple(Uint8(44), Uint8(45)))),
+			want: hb(`
+				000000000000000000000000000000000000000000000000000000000000002a
+				000000000000000000000000000000000000000000000000000000000000002b
+				000000000000000000000000000000000000000000000000000000000000002c
+				000000000000000000000000000000000000000000000000000000000000002d
+			`),
+		},
+		{
+			desc:  "nested dynamic tuples",
+			input: Tuple(Tuple(Uint8(42), Tuple(Uint8(43), String("foo")))),
+			want: hb(`
+				0000000000000000000000000000000000000000000000000000000000000020
+				000000000000000000000000000000000000000000000000000000000000002a
+				0000000000000000000000000000000000000000000000000000000000000040
+				000000000000000000000000000000000000000000000000000000000000002b
+				0000000000000000000000000000000000000000000000000000000000000040
+				0000000000000000000000000000000000000000000000000000000000000003
+				666f6f0000000000000000000000000000000000000000000000000000000000
+			`),
+		},
 	}
 	for _, tc := range cases {
 		got := Encode(tc.input)
@@ -524,6 +547,30 @@ func TestDecode(t *testing.T) {
 					abit.String,
 				),
 				abit.List(abit.Uint64),
+			),
+		},
+		{
+			desc: "tuple with nested static tuple",
+			want: Tuple(Uint8(42), Uint8(43), Tuple(Uint8(44), Uint8(45))),
+			t: abit.Tuple(
+				abit.Uint8,
+				abit.Uint8,
+				abit.Tuple(
+					abit.Uint8,
+					abit.Uint8,
+				),
+			),
+		},
+		{
+			desc: "tuple with nested dynamic tuple",
+			want: Tuple(Uint8(42), String("foo"), Tuple(Uint8(44), String("bar"))),
+			t: abit.Tuple(
+				abit.Uint8,
+				abit.String,
+				abit.Tuple(
+					abit.Uint8,
+					abit.String,
+				),
 			),
 		},
 	}

--- a/abi/abit/types.go
+++ b/abi/abit/types.go
@@ -109,7 +109,7 @@ func (t Type) Signature() string {
 // A type is conidered static if the following conditions are met:
 // 1. Fixed size type (eg Uint256 or Bytes32)
 // 2. Fixed size list containing fixed size types (eg ListK(1, Uint256))
-// 3. Tuple containing only fixed sized types (eg Tuple(Uint256))
+// 3. Tuple containing only fixed sized types (eg Tuple(Tuple(Uint256)))
 // All other types are considered dynamic.
 //
 // See the Types section of the spec for more discussion:
@@ -125,7 +125,7 @@ func (t Type) Static() bool {
 		return false
 	}
 	for _, f := range t.Fields {
-		if f.Kind != S {
+		if !f.Static() {
 			return false
 		}
 	}

--- a/abi/abit/types_test.go
+++ b/abi/abit/types_test.go
@@ -96,6 +96,11 @@ func TestStatic(t *testing.T) {
 			t:    Tuple(Uint8, Bytes),
 			want: false,
 		},
+		{
+			desc: "tuple with nested static tuple",
+			t:    Tuple(Uint8, Tuple(Uint8)),
+			want: true,
+		},
 	}
 	for _, tc := range cases {
 		got := tc.t.Static()


### PR DESCRIPTION
If a nested tuple contains static fields then it is considered static. A simple, recursive Static check handles this case.