### PR TITLE
abi: bugfix for fixed length list decoding

### DIFF
--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -524,6 +524,11 @@ func TestDecode(t *testing.T) {
 			t:    abit.List(abit.String),
 		},
 		{
+			desc: "fixed size list of static types",
+			want: ListK(2, Uint8(42), Uint8(43)),
+			t:    abit.ListK(2, abit.Uint8),
+		},
+		{
 			desc: "tuple static",
 			want: Tuple(Uint64(0)),
 			t:    abit.Tuple(abit.Uint64),

--- a/abi/abit/types.go
+++ b/abi/abit/types.go
@@ -132,26 +132,6 @@ func (t Type) Static() bool {
 	return true
 }
 
-// Returns the number of bytes that the type will
-// occupy if the type is static.
-//
-// Returns 0 if the type is dynamic.
-func (t Type) Size() int {
-	if !t.Static() {
-		return 0
-	}
-	switch t.Kind {
-	case S:
-		return 32
-	case T:
-		return 32 * len(t.Fields)
-	case L:
-		return 32 * int(t.Length)
-	default:
-		return 0
-	}
-}
-
 var (
 	Address = Type{
 		Name: "address",

--- a/abi/abit/types_test.go
+++ b/abi/abit/types_test.go
@@ -5,46 +5,6 @@ import (
 	"testing"
 )
 
-func TestSize(t *testing.T) {
-	cases := []struct {
-		desc string
-		t    Type
-		want int
-	}{
-		{
-			desc: "simple static",
-			t:    Uint8,
-			want: 32,
-		},
-		{
-			desc: "fixed size list of fixed size types",
-			t:    ListK(2, Uint8),
-			want: 64,
-		},
-		{
-			desc: "dynamic sized list of static types",
-			t:    List(Uint8),
-			want: 0,
-		},
-		{
-			desc: "tuple with static fields",
-			t:    Tuple(Uint8),
-			want: 32,
-		},
-		{
-			desc: "tuple with dynamic fields",
-			t:    Tuple(Bytes),
-			want: 0,
-		},
-	}
-	for _, tc := range cases {
-		got := tc.t.Size()
-		if got != tc.want {
-			t.Errorf("%q got: %d want: %d", tc.desc, got, tc.want)
-		}
-	}
-}
-
 func TestStatic(t *testing.T) {
 	cases := []struct {
 		desc string


### PR DESCRIPTION
This commit adds support for decoding fixed length lists. The solution also improves the architecture of the code as it leverages tuple decoding instead of doing it's own decoding. This means we can remove the Size method on abit.Type. After all, the ABI spec instructs implementations to treat lists as tuples.