### PR TITLE
abi: remove unused code

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -144,14 +144,6 @@ func (it Item) Bytes32() [32]byte {
 	return *(*[32]byte)(it.d)
 }
 
-func (it Item) BytesSlice() [][]byte {
-	var res [][]byte
-	for i := range it.l {
-		res = append(res, it.l[i].Bytes())
-	}
-	return res
-}
-
 func Address(a [20]byte) Item {
 	return Item{Type: abit.Address, d: a[:]}
 }
@@ -163,28 +155,12 @@ func (it Item) Address() [20]byte {
 	return *(*[20]byte)(it.d[12:])
 }
 
-func (it Item) AddressSlice() [][20]byte {
-	var res [][20]byte
-	for i := range it.l {
-		res = append(res, it.l[i].Address())
-	}
-	return res
-}
-
 func String(s string) Item {
 	return Item{Type: abit.String, d: []byte(s)}
 }
 
 func (it Item) String() string {
 	return string(it.d)
-}
-
-func (it Item) StringSlice() []string {
-	var res []string
-	for i := range it.l {
-		res = append(res, it.l[i].String())
-	}
-	return res
 }
 
 func Bool(b bool) Item {
@@ -202,14 +178,6 @@ func (it Item) Bool() bool {
 	return it.d[31] == 1
 }
 
-func (it Item) BoolSlice() []bool {
-	var res []bool
-	for i := range it.l {
-		res = append(res, it.l[i].Bool())
-	}
-	return res
-}
-
 func BigInt(i *big.Int) Item {
 	var b [32]byte
 	i.FillBytes(b[:])
@@ -225,14 +193,6 @@ func (it Item) BigInt() *big.Int {
 	return x
 }
 
-func (it Item) BigIntSlice() []*big.Int {
-	var res []*big.Int
-	for i := range it.l {
-		res = append(res, it.l[i].BigInt())
-	}
-	return res
-}
-
 func Uint64(i uint64) Item {
 	var b [32]byte
 	bint.Encode(b[:], i)
@@ -243,14 +203,6 @@ func (it Item) Uint64() uint64 {
 	return bint.Decode(it.d)
 }
 
-func (it Item) Uint64Slice() []uint64 {
-	var res []uint64
-	for i := range it.l {
-		res = append(res, it.l[i].Uint64())
-	}
-	return res
-}
-
 func Uint8(i uint8) Item {
 	var b [32]byte
 	bint.Encode(b[:], uint64(i))
@@ -259,14 +211,6 @@ func Uint8(i uint8) Item {
 
 func (it Item) Uint8() uint8 {
 	return uint8(bint.Decode(it.d))
-}
-
-func (it Item) Uint8Slice() []uint8 {
-	var res []uint8
-	for i := range it.l {
-		res = append(res, it.l[i].Uint8())
-	}
-	return res
 }
 
 func ListK(k uint, items ...Item) Item {


### PR DESCRIPTION
These slice methods were added for DX. Now that genabi exists, for optimal DX, users should generate structs using genabi.

For machine optimized access to decoded items, users can still access
the data with: At, Len, etc.