### PR TITLE
abi: bugfix. encoding dynamic after wide static

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -103,6 +103,15 @@ func Encode(item Item) []byte {
 		item.Kind = 't'
 		return append(res, Encode(item)...)
 	case 't':
+		var hlen int
+		for _, it := range item.l {
+			switch {
+			case it.Static:
+				hlen += it.Size
+			default:
+				hlen += 32
+			}
+		}
 		var head, tail []byte
 		for _, it := range item.l {
 			if it.Static {
@@ -110,7 +119,7 @@ func Encode(item Item) []byte {
 				continue
 			}
 			var offset [32]byte
-			bint.Encode(offset[:], uint64(len(item.l)*32+len(tail)))
+			bint.Encode(offset[:], uint64(hlen+len(tail)))
 			head = append(head, offset[:]...)
 			tail = append(tail, Encode(it)...)
 		}

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -380,6 +380,17 @@ func TestDecode(t *testing.T) {
 			),
 		},
 		{
+			desc: "tuple with large (> 32) initial field and dynamic second field",
+			want: Tuple(
+				Tuple(Uint8(42), Uint8(43)),
+				Array(String("foo")),
+			),
+			input: schema.Tuple(
+				schema.Tuple(schema.Static(), schema.Static()),
+				schema.Array(schema.Dynamic()),
+			),
+		},
+		{
 			desc: "tuple with list of tuples",
 			want: Tuple(
 				Uint8(42),


### PR DESCRIPTION
The prior code assumed that each field's header is 32 bytes --which is correct for elementary static types, and for dynamic types, but is incorrect for nested static tuples or static size arrays with static elements.

This patch leverages the fact that the type's Size field is recursively computed so that we account for arbitrary nesting.