### PR TITLE
genabi: don't accidently export generated vars

### DIFF
--- a/genabi/gen.go
+++ b/genabi/gen.go
@@ -193,6 +193,12 @@ type structHelper struct {
 	Inputs []Input
 }
 
+func lower(str string) string {
+	c := camel(str)
+	u := unicode.ToLower(rune(c[0:1][0]))
+	return string(u) + c[1:]
+}
+
 func camel(str string) string {
 	var (
 		in  = []rune(str)
@@ -296,6 +302,7 @@ func Gen(pkg string, js []byte) ([]byte, error) {
 
 	t := template.New("abi").Funcs(template.FuncMap{
 		"camel":    camel,
+		"lower":    lower,
 		"goType":   goType,
 		"itemFunc": itemFunc,
 		"sub": func(x, y int) int {

--- a/genabi/template.txt
+++ b/genabi/template.txt
@@ -81,8 +81,8 @@ import (
 	{{ template "struct" structHelper .Name .Inputs -}}
 
 	var (
-		{{ .Name }}Signature = {{ .SigHashLiteral }}
-		{{ .Name }}Schema = schema.Parse("{{ .SchemaSignature }}")
+		{{ lower .Name }}Signature = {{ .SigHashLiteral }}
+		{{ lower .Name }}Schema = schema.Parse("{{ .SchemaSignature }}")
 	)
 
 	// Event Signature:
@@ -97,11 +97,11 @@ import (
 	// event inputs from the log's data field into [{{ camel .Name }}]:
 	//	{{ .SchemaSignature }}
 	func Match{{ camel .Name }}(l abi.Log) ({{ camel .Name}}, bool) {
-		if {{ .Name }}Signature != l.Topics[0] {
+		if {{ lower .Name }}Signature != l.Topics[0] {
 			return {{ camel .Name }}{}, false
 		}
 		{{ if gt (len (unindexed .Inputs)) 0 -}}
-			item := abi.Decode(l.Data, {{ .Name }}Schema)
+			item := abi.Decode(l.Data, {{ lower .Name }}Schema)
 			res := decode{{ camel .Name}}(item)
 		{{ else -}}
 			res := {{ camel .Name}}{}


### PR DESCRIPTION
Without this code, capitalized strings in the abi json file would be exported in generated code.