### PR TITLE
abi: return number of bytes read from abi.Decode

### DIFF
--- a/genabi/example/example.go
+++ b/genabi/example/example.go
@@ -114,7 +114,7 @@ func MatchTransfer(l abi.Log) (Transfer, bool) {
 	if len(l.Topics) > 0 && transferSignature != l.Topics[0] {
 		return Transfer{}, false
 	}
-	item := abi.Decode(l.Data, transferSchema)
+	_, item := abi.Decode(l.Data, transferSchema)
 	res := decodeTransfer(item)
 	res.item = item
 	res.From = abi.Bytes(l.Topics[1][:]).Address()

--- a/genabi/template.txt
+++ b/genabi/template.txt
@@ -110,7 +110,7 @@ import (
 			return {{ camel .Name }}{}, false
 		}
 		{{ if gt (len (unindexed .Inputs)) 0 -}}
-			item := abi.Decode(l.Data, {{ lower .Name }}Schema)
+			_, item := abi.Decode(l.Data, {{ lower .Name }}Schema)
 			res := decode{{ camel .Name}}(item)
 			res.item = item
 		{{ else -}}


### PR DESCRIPTION
It is not uncommon for ethereum calldata to include an abi encoded payload with extra bytes appended. In order to seperate the abi encoded data from the extra bytes, Decode will return the number of bytes read so that callers can safely extract the extra bytes.

This commit adds a test to ensure that Decode will work with input that contains extra bytes.