### PR TITLE
abi: bugfix. elementary, dynamic types of length 0

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -169,6 +169,9 @@ func Decode(input []byte, t schema.Type) (*Item, int, error) {
 		return item, 32, nil
 	case 'd':
 		length := int(bint.Decode(input[:32]))
+		if length == 0 {
+			return item, 32, nil
+		}
 		nbytes := length + (32 - (length % 32))
 		if len(input) < 32+length {
 			return item, 0, errors.New("EOF")

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -450,6 +450,11 @@ func TestDecode_NumBytes(t *testing.T) {
 			want:   64,
 		},
 		{
+			item:   Bytes([]byte{}),
+			schema: schema.Dynamic(),
+			want:   32,
+		},
+		{
 			item:   String("foooooooooooooooooooooooooooooooo"), //len=33
 			schema: schema.Dynamic(),
 			want:   96,

--- a/abi/item.go
+++ b/abi/item.go
@@ -57,7 +57,7 @@ func (item *Item) Bool() bool {
 }
 
 func Bytes(d []byte) *Item {
-	return &Item{Type: schema.Static(), d: d}
+	return &Item{Type: schema.Dynamic(), d: d}
 }
 
 func (it *Item) Bytes() []byte {


### PR DESCRIPTION
In the case of a dynamic, elementary types, the nbytes calculation works only when length > 0.

If length == 0, return early and don't use the nbytes calculation.