### PR TITLE
abi/Parse: allow for extra spaces in schema definitions

### DIFF
--- a/abi/schema/schema.go
+++ b/abi/schema/schema.go
@@ -97,6 +97,8 @@ func (t Type) size() int {
 }
 
 func Parse(s string) Type {
+	s = strings.ReplaceAll(s, " ", "")
+
 	switch {
 	case strings.HasSuffix(s, "]"):
 		var num string

--- a/abi/schema/schema.go
+++ b/abi/schema/schema.go
@@ -98,7 +98,6 @@ func (t Type) size() int {
 
 func Parse(s string) Type {
 	s = strings.ReplaceAll(s, " ", "")
-
 	switch {
 	case strings.HasSuffix(s, "]"):
 		var num string

--- a/abi/schema/schema_test.go
+++ b/abi/schema/schema_test.go
@@ -63,6 +63,11 @@ func TestParse(t *testing.T) {
 			want:  Tuple(Static(), Tuple(Array(Static()))),
 		},
 		{
+			desc:  "nested tuple with array and extra space",
+			input: "(bytes32, (bytes32[]))",
+			want:  Tuple(Static(), Tuple(Array(Static()))),
+		},
+		{
 			desc:  "complex",
 			input: "((address,bytes32,bytes,(uint8,uint8))[][])",
 			want: Tuple(

--- a/abi/schema/schema_test.go
+++ b/abi/schema/schema_test.go
@@ -18,6 +18,11 @@ func TestParse(t *testing.T) {
 			want:  Tuple(Static()),
 		},
 		{
+			desc:  "single static with spaces",
+			input: "( uint8 )",
+			want:  Tuple(Static()),
+		},
+		{
 			desc:  "single dynamic",
 			input: "(bytes)",
 			want:  Tuple(Dynamic()),
@@ -38,6 +43,11 @@ func TestParse(t *testing.T) {
 			want:  Tuple(Static(), Dynamic()),
 		},
 		{
+			desc:  "mixed with spaces",
+			input: "( bytes32, bytes )",
+			want:  Tuple(Static(), Dynamic()),
+		},
+		{
 			desc:  "fixed size array",
 			input: "(bytes32,bytes)[2]",
 			want:  ArrayK(2, Tuple(Static(), Dynamic())),
@@ -45,6 +55,11 @@ func TestParse(t *testing.T) {
 		{
 			desc:  "array",
 			input: "(bytes32,bytes)[]",
+			want:  Array(Tuple(Static(), Dynamic())),
+		},
+		{
+			desc:  "array with spaces",
+			input: "( bytes32 , bytes ) []",
 			want:  Array(Tuple(Static(), Dynamic())),
 		},
 		{
@@ -60,11 +75,6 @@ func TestParse(t *testing.T) {
 		{
 			desc:  "nested tuple with array",
 			input: "(bytes32,(bytes32[]))",
-			want:  Tuple(Static(), Tuple(Array(Static()))),
-		},
-		{
-			desc:  "nested tuple with array and extra space",
-			input: "(bytes32, (bytes32[]))",
 			want:  Tuple(Static(), Tuple(Array(Static()))),
 		},
 		{


### PR DESCRIPTION
this adds a test for an ABI with spaces, which is failing before I added the line that removes spaces before parsing. let me know if there's a better way that you'd like to accomplish this!