### PR TITLE
.github: add `go mod tidy` action

### DIFF
--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  name: go mod tidy
+  name: "go mod tidy"
   runs-on: ubuntu-latest
   steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -6,27 +6,28 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  name: "go mod tidy"
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v2
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: "1.20"
-    # Cache Go modules if go.sum is unchanged.
-    # Docs here: https://github.com/actions/cache/blob/9c7b3e90bdf39569c497c98e469f8a00e061c43f/examples.md#linux-1
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: check 'go mod tidy'
-      run: |
-        go mod tidy
-        echo
-        echo
-        git diff --name-only --exit-code || (echo "Please run 'go mod tidy'."; exit 1)
+  build:
+    name: "go mod tidy"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+      # Cache Go modules if go.sum is unchanged.
+      # Docs here: https://github.com/actions/cache/blob/9c7b3e90bdf39569c497c98e469f8a00e061c43f/examples.md#linux-1
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: check 'go mod tidy'
+        run: |
+          go mod tidy
+          echo
+          echo
+          git diff --name-only --exit-code || (echo "Please run 'go mod tidy'."; exit 1)

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -1,0 +1,33 @@
+name: go
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  name: go mod tidy
+  runs-on: ubuntu-latest
+  steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: "1.20"
+    # Cache Go modules if go.sum is unchanged.
+    # Docs here: https://github.com/actions/cache/blob/9c7b3e90bdf39569c497c98e469f8a00e061c43f/examples.md#linux-1
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: check 'go mod tidy'
+      run: |
+        go mod tidy
+        echo
+        echo
+        git diff --name-only --exit-code || (echo "Please run 'go mod tidy'."; exit 1)

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -9,8 +9,7 @@ jobs:
   name: go mod tidy
   runs-on: ubuntu-latest
   steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
     - name: Set up Go
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,4 +1,4 @@
-name: go test
+name: go
 
 on:
   push:

--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,18 @@ go 1.20
 require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
 	github.com/golang/snappy v0.0.4
+	github.com/holiman/uint256 v1.2.1
 	github.com/kr/pretty v0.3.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/net v0.1.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
+	kr.dev/diff v0.3.0
 )
 
 require (
-	github.com/holiman/uint256 v1.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20220218215828-6cf2b201936e // indirect
 	golang.org/x/sys v0.1.0 // indirect
-	kr.dev/diff v0.3.0 // indirect
 )


### PR DESCRIPTION
This pull request adds an action that ensures go mod tidy has been run.

We could add it in as part of the `go test` action - bit of personal preference here with regards to wanting to break it out. Happy to just add the step to the end if you prefer.

The primary reason why I like having `go mod tidy` be a separate workflow is that it's useful as a reviewer or committer to know at a glance if the test is failing / the code doesn't build vs someone just needs to run `go mod tidy`.