### PR TITLE
genabi: bugfix. decoding non-tuple arrays

### DIFF
--- a/genabi/example/example.json
+++ b/genabi/example/example.json
@@ -1,5 +1,12 @@
 [
 	{
+		"name": "nestedSlices",
+		"type": "event",
+		"inputs": [
+			{"type": "string[]", "name": "strings"}
+		]
+	},
+	{
 		"name": "transfer",
 		"type": "event",
 		"anonymous": false,

--- a/genabi/example/example_test.go
+++ b/genabi/example/example_test.go
@@ -25,6 +25,23 @@ func TestGenZero(t *testing.T) {
 	}
 }
 
+func TestNestedSlices(t *testing.T) {
+	log := abi.Log{
+		Topics: [][32]byte{nestedSlicesSignature},
+		Data: abi.Encode(abi.Tuple(
+			abi.Array(abi.String("foo"), abi.String("bar")),
+		)),
+	}
+	got, err := MatchNestedSlices(log)
+	if err != nil {
+		t.Errorf("want: nil got: %v", err)
+	}
+	want := []string{"foo", "bar"}
+	if !reflect.DeepEqual(want, got.Strings) {
+		t.Errorf("want: %v got: %v", want, got.Strings)
+	}
+}
+
 func BenchmarkMatch(b *testing.B) {
 	log := abi.Log{
 		Topics: [][32]byte{

--- a/genabi/template.txt
+++ b/genabi/template.txt
@@ -80,7 +80,7 @@ import (
 			{{ if hasTuple .Input -}}
 				{{ .Input.Name}}{{ .Index }}[i{{ .Index }}] = decode{{ camel .Input.Name }}({{ .Input.Name }}Item{{ .Index }}.At(i{{ .Index}}))
 			{{ else -}}
-				{{ .Input.Name}}{{ .Index }}[i{{ .Index }}] = {{ .Input.Name }}Item{{ .Index }}.{{ itemFunc .Input }}
+				{{ .Input.Name}}{{ .Index }}[i{{ .Index }}] = {{ .Input.Name }}Item{{ .Index }}.At(i{{ .Index}}).{{ itemFunc .Input }}
 			{{ end -}}
 		}
 	{{ end -}}


### PR DESCRIPTION
the list template was previously producing code that looked like this for `[]address` types (and other non tuple list types)

```go

targetsItem0 := item.At(2)
targets0 := make([][20]byte, targetsItem0.Len())
for i0 := 0; i0 < targetsItem0.Len(); i0++ {
	targets0[i0] = targetsItem0.Address()
}
```

which didn't work because on the line where `targetsItem0.Address()` is called, no index to the list is actually passed. causing the data to not scan correctly

this pull request passes in the index to the list generation code, which now produces code of this shape:


```go
targetsItem0 := item.At(2)
targets0 := make([][20]byte, targetsItem0.Len())
for i0 := 0; i0 < targetsItem0.Len(); i0++ {
	targets0[i0] = targetsItem0.At(i0).Address()
}
```

tested this and it worked with the contract that i was working with!