### PR TITLE
.github/chore: move off deprecated worker action

### DIFF
--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -10,7 +10,7 @@ jobs:
     name: "go mod tidy"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -10,7 +10,7 @@ jobs:
     name: go test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
the checkout@v2 action is deprecated as it uses node 12.
this pr updates to v3, which is not deprecated