### PR TITLE
rlp: use values instead of pointers

### DIFF
--- a/discv4/discover.go
+++ b/discv4/discover.go
@@ -166,7 +166,7 @@ func (p *process) handleFindNode(req *enr.Record, packet []byte) error {
 	}
 	var (
 		recs  = p.ktable.FindClosest(isxhash.Keccak32(item.At(0).Bytes()), 16)
-		nodes []*rlp.Item
+		nodes []rlp.Item
 	)
 	for _, rec := range recs {
 		id := isxsecp256k1.Encode(rec.PublicKey)
@@ -321,7 +321,7 @@ func (p *process) handlePong(req *enr.Record, packet []byte) error {
 // - packet-header = hash || signature || packet-type
 // - hash = keccak256(signature || packet-type || packet-data)
 // - signature = sign(packet-type || packet-data)
-func (p *process) write(pt byte, to *net.UDPAddr, it *rlp.Item) ([]byte, error) {
+func (p *process) write(pt byte, to *net.UDPAddr, it rlp.Item) ([]byte, error) {
 	pd := rlp.Encode(it)
 	var ts []byte
 	ts = append(ts, pt)

--- a/enr/enr.go
+++ b/enr/enr.go
@@ -126,7 +126,7 @@ func UnmarshalText(str string) (Record, error) {
 	return decode(item)
 }
 
-func decode(item *rlp.Item) (Record, error) {
+func decode(item rlp.Item) (Record, error) {
 	var rec = Record{}
 	rec.Sequence = item.At(1).Uint64()
 	rec.Signature = item.At(0).Bytes()
@@ -196,7 +196,7 @@ func (r *Record) MarshalRLP(prv *secp256k1.PrivateKey) ([]byte, error) {
 	// i.e. any key may be present only once. The keys can technically
 	// be any byte sequence, but ASCII text is preferred. Key names in
 	// the table below have pre-defined meaning.
-	var items []*rlp.Item
+	var items []rlp.Item
 	items = append(items, rlp.Uint64(r.Sequence))
 	items = append(items, rlp.String("id"))
 	items = append(items, rlp.String(r.IDScheme))
@@ -235,6 +235,6 @@ func (r *Record) MarshalRLP(prv *secp256k1.PrivateKey) ([]byte, error) {
 		return nil, err
 	}
 	sigNoFmt := sig[:len(sig)-1] // remove formatting byte
-	items = append([]*rlp.Item{rlp.Bytes(sigNoFmt)}, items...)
+	items = append([]rlp.Item{rlp.Bytes(sigNoFmt)}, items...)
 	return rlp.Encode(rlp.List(items...)), nil
 }

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -36,7 +36,7 @@ func FuzzEncode(f *testing.F) {
 	)
 	f.Add(numItems, payload)
 	f.Fuzz(func(t *testing.T, n uint64, d []byte) {
-		var items []*Item
+		var items []Item
 		for i := 0; i < int(n); i++ {
 			items = append(items, Bytes(d))
 		}
@@ -56,18 +56,6 @@ func BenchmarkEncode(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		Encode(Bytes(payload))
-	}
-}
-
-func BenchmarkDecode_List(b *testing.B) {
-	ei := Encode(List(String("foo"), List(String("bar"), String("baz"))))
-	b.ReportAllocs()
-	for n := 0; n < b.N; n++ {
-		item, err := Decode(ei)
-		if err != nil {
-			b.Fatal(err)
-		}
-		item.Done()
 	}
 }
 
@@ -188,7 +176,7 @@ func TestDecodeZero(t *testing.T) {
 func TestDecode(t *testing.T) {
 	cases := []struct {
 		desc string
-		item *Item
+		item Item
 	}{
 		{
 			"empty bytes",
@@ -240,7 +228,7 @@ func TestDecode(t *testing.T) {
 func TestEncode(t *testing.T) {
 	cases := []struct {
 		desc string
-		item *Item
+		item Item
 		want []byte
 	}{
 		{

--- a/rlp/types.go
+++ b/rlp/types.go
@@ -14,63 +14,56 @@ import (
 
 var errNoData = errors.New("requested item contains 0 bytes")
 
-func Bytes(b []byte) *Item {
-	item := getItem()
-	if b != nil {
-		item.d = b
+func Bytes(b []byte) Item {
+	if b == nil {
+		return Item{d: []byte{}}
 	}
-	return item
+	return Item{d: b}
 }
 
-func (i *Item) Bytes() []byte {
+func (i Item) Bytes() []byte {
 	return i.d
 }
 
-func Uint16(n uint16) *Item {
-	item := getItem()
-	item.d = bint.Encode(nil, uint64(n))
-	return item
+func Uint16(n uint16) Item {
+	return Item{d: bint.Encode(nil, uint64(n))}
 }
 
-func (i *Item) Uint16() uint16 {
+func (i Item) Uint16() uint16 {
 	return uint16(bint.Decode(i.d))
 }
 
-func Uint64(n uint64) *Item {
-	item := getItem()
-	item.d = bint.Encode(nil, n)
-	return item
+func Uint64(n uint64) Item {
+	return Item{d: bint.Encode(nil, n)}
 }
 
-func (i *Item) Uint64() uint64 {
+func (i Item) Uint64() uint64 {
 	return bint.Decode(i.d)
 }
 
-func String(s string) *Item {
-	item := getItem()
-	item.d = []byte(s)
-	return item
+func String(s string) Item {
+	return Item{d: []byte(s)}
 }
 
-func (i *Item) String() string {
+func (i Item) String() string {
 	return string(i.d)
 }
 
-func Time(t time.Time) *Item {
+func Time(t time.Time) Item {
 	return Uint64(uint64(t.Unix()))
 }
 
-func (i *Item) Time() time.Time {
+func (i Item) Time() time.Time {
 	return time.Unix(int64(i.Uint64()), 0)
 }
 
 // Uncompressed secpk256k1 public key
-func Secp256k1PublicKey(pubk *secp256k1.PublicKey) *Item {
+func Secp256k1PublicKey(pubk *secp256k1.PublicKey) Item {
 	b := isxsecp256k1.Encode(pubk)
 	return Bytes(b[:])
 }
 
-func (i *Item) Secp256k1PublicKey() (*secp256k1.PublicKey, error) {
+func (i Item) Secp256k1PublicKey() (*secp256k1.PublicKey, error) {
 	switch len(i.d) {
 	case 0:
 		return nil, errNoData
@@ -87,7 +80,7 @@ func (i *Item) Secp256k1PublicKey() (*secp256k1.PublicKey, error) {
 	}
 }
 
-func (i *Item) Hash() ([32]byte, error) {
+func (i Item) Hash() ([32]byte, error) {
 	var h [32]byte
 	if len(i.d) == 0 {
 		return h, errNoData
@@ -99,7 +92,7 @@ func (i *Item) Hash() ([32]byte, error) {
 	return h, nil
 }
 
-func (i *Item) IP() (net.IP, error) {
+func (i Item) IP() (net.IP, error) {
 	switch len(i.d) {
 	case 0:
 		return nil, errNoData
@@ -110,31 +103,27 @@ func (i *Item) IP() (net.IP, error) {
 	}
 }
 
-func (i *Item) Bytes32() ([32]byte, error) {
+func (i Item) Bytes32() ([32]byte, error) {
 	if len(i.d) != 32 {
 		return [32]byte{}, errors.New("must be exactly 32 bytes")
 	}
 	return *(*[32]byte)(i.d), nil
 }
 
-func (i *Item) Bytes65() ([65]byte, error) {
+func (i Item) Bytes65() ([65]byte, error) {
 	if len(i.d) != 65 {
 		return [65]byte{}, errors.New("must be exactly 65 bytes")
 	}
 	return *(*[65]byte)(i.d), nil
 }
 
-func Byte(b byte) *Item {
-	item := getItem()
+func Byte(b byte) Item {
 	if b == 0 {
-		item.d = []byte{}
+		return Item{d: []byte{}}
 	}
-	item.d = []byte{b}
-	return item
+	return Item{d: []byte{b}}
 }
 
-func Int(n int) *Item {
-	item := getItem()
-	item.d = bint.Encode(nil, uint64(n))
-	return item
+func Int(n int) Item {
+	return Item{d: bint.Encode(nil, uint64(n))}
 }

--- a/rlpx/rlpx.go
+++ b/rlpx/rlpx.go
@@ -289,7 +289,7 @@ func (s *session) HandleMessage(d []byte) error {
 	return nil
 }
 
-func (s *session) HandleHello(item *rlp.Item) error {
+func (s *session) HandleHello(item rlp.Item) error {
 	if len(item.List()) < 5 {
 		return errors.New(fmt.Sprintf("HandleHello: expected rlp list of at least 5, got %d", len(item.List())))
 	}
@@ -304,12 +304,12 @@ func (s *session) HandleHello(item *rlp.Item) error {
 	return nil
 }
 
-func (s *session) HandleDisconnect(item *rlp.Item) error {
+func (s *session) HandleDisconnect(item rlp.Item) error {
 	s.log("<disconnect reason=%d\n", item.Uint16())
 	return nil
 }
 
-func (s *session) HandleEthStatus(item *rlp.Item) error {
+func (s *session) HandleEthStatus(item rlp.Item) error {
 	s.log("<status version=%d network=%d difficulty=%d\n", item.At(0).Uint16(), item.At(1).Uint16(), item.At(2).Uint64())
 	return nil
 }


### PR DESCRIPTION
I don't like using sync.Pool as a band aid for performance. The extra complexity of pointers and the opaque nature of sync.Pool makes reasoning about GC performance more difficult than it ought to be.

In the particular case of RLP decoding, the actual problem is that we blindly decode nested structures. This wholesale decoding leads more allocations than may be necessary. Instead, there should be an API that allows callers to decode one "level" at a time. This reduces computation and allocations at the cost of a little more work on the caller's behalf.

A forthcoming pull request will contain this new API.

Revert "rlp: use sync.Pool for Items"
This reverts commit d4a1fafd415f74032ecf91608ab3a4dc30f70b10.

Revert "rlp: use pointers to rlp Items"
This reverts commit d9c1dbef59b1bec1ef6e36bbca03b64bc34cdca1.