### PR TITLE
rlp: performance. compare single byte instead of string

### DIFF
--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -5,8 +5,6 @@
 package rlp
 
 import (
-	"bytes"
-
 	"github.com/indexsupply/x/bint"
 )
 
@@ -80,7 +78,7 @@ func Bytes(input []byte) []byte {
 	switch {
 	case len(input) == 0:
 		return nil
-	case bytes.Equal(input, []byte{0x80}):
+	case len(input) == 1 && input[0] == 0x80:
 		return nil
 	case input[0] <= str1H:
 		return input[0:1]


### PR DESCRIPTION
Under the hood, bytes.Equal does the following:

	return string(a) == string(b) bytes.go:20

This is inefficient since we only care if the entire input is equal to:

	[]byte{0x80}