### PR TITLE
rlp: clean up Iterator

### DIFF
--- a/enr/enr.go
+++ b/enr/enr.go
@@ -219,11 +219,11 @@ func (r *Record) MarshalRLP(prv *secp256k1.PrivateKey) ([]byte, error) {
 	// signature of the hash. The resulting 64-byte signature is
 	// encoded as the concatenation of the r and s signature values
 	// (the recovery ID v is omitted).
-	sig, err := wsecp256k1.Sign(prv, isxhash.Keccak(rlp.EncodeList(buf...)))
+	sig, err := wsecp256k1.Sign(prv, isxhash.Keccak(rlp.List(rlp.Encode(buf...))))
 	if err != nil {
 		return nil, err
 	}
 	sigNoFmt := sig[:len(sig)-1] // remove formatting byte
 	buf = append([][]byte{sigNoFmt}, buf...)
-	return rlp.EncodeList(buf...), nil
+	return rlp.List(rlp.Encode(buf...)), nil
 }


### PR DESCRIPTION
Commit 647880db introduced a more effeciant way of dealing with RLP encoded data. This commit goes back to clean up the implementation. It also fixes a design bug. In the process of ditching the Item struct, we lost the ability to properly encode lists of lists. This commit changes the encoding API slightly, and to be honest, it's not my favorite.

The problem with EncodeList is that it blindly called Encode on each input -- which is obviously not the right thing to do for an already-encoded-list.

The solution I came up with is to provide 2 encoding functions. Both functions take homogeneous arguments. In the case of Encode, it only takes non-encoded, single values. In the case of List, it only takes already encoded values. I added some sugar to Encode such that you can encode a set of byte values in a single shot, which allows for code like:

	List(Encode(foo, bar, baz))

If you want to encode a list that has a mix of atomic byte values and sub-lists, the code is a bit more vervose. eg:

	List(Encode(foo), List(Encode(bar, baz)), Encode(qar))

Perhaps there is a better design out there, but I can't find it right now.

The bottom line here is that the decoding operations have become as simple as I can possibly imagine. I don't believe there is extra work happening and this will make performance better and easier to diagnose.