### PR TITLE
e2pg: s/driver/task

### DIFF
--- a/cmd/e2pg/dashboard.go
+++ b/cmd/e2pg/dashboard.go
@@ -11,14 +11,14 @@ import (
 )
 
 type dashHandler struct {
-	drivers      []*e2pg.Driver
+	tasks        []*e2pg.Task
 	clientsMutex sync.Mutex
 	clients      map[string]chan e2pg.StatusSnapshot
 }
 
-func newDashHandler(drivers []*e2pg.Driver, snaps <-chan e2pg.StatusSnapshot) *dashHandler {
+func newDashHandler(tasks []*e2pg.Task, snaps <-chan e2pg.StatusSnapshot) *dashHandler {
 	dh := &dashHandler{
-		drivers: drivers,
+		tasks:   tasks,
 		clients: make(map[string]chan e2pg.StatusSnapshot),
 	}
 	go func() {
@@ -103,11 +103,11 @@ func (dh *dashHandler) Index(w http.ResponseWriter, r *http.Request) {
 			</head>
 			<body>
 				<h1>E2PG</h1>
-				<div id="driver">
-					<table id="driver-status">
+				<div id="tasks">
+					<table id="tasks-status">
 						<thead>
 							<tr>
-								<td>Driver</td>
+								<td>Task</td>
 								<td>Block</td>
 								<td>Hash</td>
 								<td>Blocks</td>
@@ -159,8 +159,8 @@ func (dh *dashHandler) Index(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	snaps := make(map[string]e2pg.StatusSnapshot)
-	for _, drv := range dh.drivers {
-		snaps[drv.Name] = drv.Status()
+	for _, task := range dh.tasks {
+		snaps[task.Name] = task.Status()
 	}
 	err = tmpl.Execute(w, snaps)
 	if err != nil {

--- a/docs/e2pg/readme.md
+++ b/docs/e2pg/readme.md
@@ -125,7 +125,7 @@ To start with the network's current latest block, use the following flag:
 If E2PG gets a block from its Ethereum source where the new block's parent doesn't match the local block's hash, then the local block, and all it's integration data are deleted. After the deletion, E2PG attempts to add the new block. This process is repeated up to 10 times or until a hash/parent match is made. If there is a reorg of more than 10 blocks the database transaction is rolled back (meaning no data was deleted) and E2PG will halt progress. This condition requires operator intervention via SQL:
 
 ```sql
-delete from driver where number > XXX;
+delete from task where number > XXX;
 delete from nft_transfers where block_number > XXX;
 --etc...
 ```

--- a/e2pg/schema.sql
+++ b/e2pg/schema.sql
@@ -1,4 +1,5 @@
-CREATE TABLE main_driver (
+CREATE TABLE task (
+	id smallint not null,
 	number bigint,
 	hash bytea,
 	insert_at timestamptz default now()

--- a/integrations/testhelper/helper.go
+++ b/integrations/testhelper/helper.go
@@ -45,9 +45,9 @@ func New(tb testing.TB) *H {
 	}
 }
 
-// Reset the driver table. Call this in-between test cases
+// Reset the task table. Call this in-between test cases
 func (th *H) Reset() {
-	_, err := th.PG.Exec(context.Background(), "truncate table main_driver")
+	_, err := th.PG.Exec(context.Background(), "truncate table task")
 	check(th.tb, err)
 }
 
@@ -66,14 +66,14 @@ func (th *H) Done() {
 // the debug_dbAncient and debug_dbGet methods.
 func (th *H) Process(ig e2pg.Integration, n uint64) {
 	var (
-		geth   = e2pg.NewGeth(th.gt.FileCache, th.gt.Client)
-		driver = e2pg.NewDriver("main", 1, 1, geth, th.PG, ig)
+		geth = e2pg.NewGeth(th.gt.FileCache, th.gt.Client)
+		task = e2pg.NewTask(0, "main", 1, 1, geth, th.PG, ig)
 	)
 	cur, err := geth.Hash(n)
 	check(th.tb, err)
 	prev, err := geth.Hash(n - 1)
 	check(th.tb, err)
 	th.gt.SetLatest(n, cur)
-	check(th.tb, driver.Insert(n-1, prev))
-	check(th.tb, driver.Converge(true, n))
+	check(th.tb, task.Insert(n-1, prev))
+	check(th.tb, task.Converge(true, n))
 }


### PR DESCRIPTION
Driver never really made sense to me. As we move the codebase to a place where there are multiple chains and multiple concurrent indexing operations, it became urgent to find a better name. I considered "index" or "job" but ended up enjoying "task" the most. For example:

> To index a new chain, create a new task and configure it with the chain id, integrations, and start/end block.

> E2PG can run multiple tasks concurrently.

> To backfill a particular contract, create a new, temporary task and
configure it with the contract integation and the start/stop block.