### PR TITLE
e2pg/config: add support for reading eth/pg urls from env

### DIFF
--- a/cmd/e2pg/config.json
+++ b/cmd/e2pg/config.json
@@ -6,7 +6,7 @@
 		"concurrency": 8,
 		"batch": 128,
 		"eth": "https://1.rlps.indexsupply.net",
-		"pg": "postgres:///e2pg",
+		"pg": "$DATABASE_URL",
 		"integrations": ["erc721", "erc1155"]
 	},
 	{
@@ -16,7 +16,7 @@
 		"concurrency": 8,
 		"batch": 1024,
 		"eth": "http://10.rlps.indexsupply.net",
-		"pg": "postgres:///e2pg",
+		"pg": "$DATABASE_URL",
 		"integrations": ["erc20"]
 	}
 ]


### PR DESCRIPTION
When configuring a task, you can set eth or pg with a '$' prefixed value indicating that the value is the name of an env var that contains the URL.