### PR TITLE
e2pg: add system for migrating database

### DIFF
--- a/cmd/dumpschema/main.go
+++ b/cmd/dumpschema/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/indexsupply/x/e2pg"
+	"github.com/indexsupply/x/pgmig"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func run(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+const tmpdb = `dumpschema`
+
+func main() {
+	ctx := context.Background()
+
+	check(run("dropdb", "--if-exists", tmpdb))
+	check(run("createdb", tmpdb))
+
+	pgp, err := pgxpool.New(ctx, fmt.Sprintf("postgres:///%s", tmpdb))
+	check(err)
+	_, err = pgp.Exec(ctx, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, "public"))
+	check(err)
+	_, err = pgp.Exec(ctx, fmt.Sprintf(`ALTER DATABASE %s SET TIMEZONE TO 'UTC'`, tmpdb))
+	check(err)
+
+	check(pgmig.Migrate(pgp, e2pg.Migrations))
+
+	var buf bytes.Buffer
+	pgdump := exec.Command("pg_dump", "-sOx", tmpdb)
+	pgdump.Stdout = &buf
+	pgdump.Stderr = os.Stderr
+	check(pgdump.Run())
+
+	f, err := os.Create(filepath.Join("e2pg", "schema.sql"))
+	check(err)
+	defer f.Close()
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(line, "--") || strings.Contains(line, "COMMENT") {
+			continue
+		}
+		_, err = f.WriteString(line + "\n")
+		check(err)
+	}
+	pgp.Close()
+	check(run("dropdb", tmpdb))
+}

--- a/cmd/e2pg/config.json
+++ b/cmd/e2pg/config.json
@@ -6,7 +6,7 @@
 		"concurrency": 8,
 		"batch": 128,
 		"eth": "https://1.rlps.indexsupply.net",
-		"pg": "$DATABASE_URL",
+		"pg": "postgres:///e2pg",
 		"integrations": ["erc721", "erc1155"]
 	},
 	{
@@ -16,7 +16,7 @@
 		"concurrency": 8,
 		"batch": 1024,
 		"eth": "http://10.rlps.indexsupply.net",
-		"pg": "$DATABASE_URL",
+		"pg": "postgres:///e2pg",
 		"integrations": ["erc20"]
 	}
 ]

--- a/docs/e2pg/readme.md
+++ b/docs/e2pg/readme.md
@@ -139,7 +139,11 @@ When configuring E2PG to run in RLPS mode, use the following flag:
 
 The PG in E2PG is a Postgres server that receives the indexed data. E2PG is developed against Postgres version 16. Although older versions may work. You can give E2PG a dedicated Postgres database or you can point E2PG at your existing Postgres database. Currently E2PG operates in Postgres' public schema, but it is possible to change that so that E2PG writes in its own schema within a database. Please file an issue if you need this feature. The schema can be found here: [e2pg/schema.sql](https://github.com/indexsupply/x/blob/main/e2pg/schema.sql)
 
-Currently there is no migration mechanism. There is an open issue for this: indexsupply/x#127
+E2PG will migrate its database on process startup. This can be disabled by using the following flag:
+
+```bash
+./e2pg ... -skip-migrate
+```
 
 ## Integrations
 

--- a/e2pg/config/config.go
+++ b/e2pg/config/config.go
@@ -47,7 +47,7 @@ func (conf Config) Empty() bool {
 // If there is no env var for s then the program will crash with an error
 //
 // if there is no $ prefix then s is returned
-func env(s string) string {
+func Env(s string) string {
 	if strings.HasPrefix(s, "$") {
 		v := os.Getenv(strings.ToUpper(strings.TrimPrefix(s, "$")))
 		if v == "" {
@@ -69,7 +69,7 @@ func NewTasks(confs ...Config) ([]*e2pg.Task, error) {
 	for _, conf := range confs {
 		pgp, ok := dbs[conf.PGURL]
 		if !ok {
-			pgp, err = pgxpool.New(context.Background(), env(conf.PGURL))
+			pgp, err = pgxpool.New(context.Background(), Env(conf.PGURL))
 			if err != nil {
 				return nil, fmt.Errorf("%s dburl invalid: %w", conf.Name, err)
 			}
@@ -77,7 +77,7 @@ func NewTasks(confs ...Config) ([]*e2pg.Task, error) {
 		}
 		node, ok := nodes[conf.ETHURL]
 		if !ok {
-			node, err = parseNode(env(conf.ETHURL), conf.FreezerPath)
+			node, err = parseNode(Env(conf.ETHURL), conf.FreezerPath)
 			if err != nil {
 				return nil, fmt.Errorf("%s ethurl invalid: %w", conf.Name, err)
 			}

--- a/e2pg/migrations.go
+++ b/e2pg/migrations.go
@@ -1,0 +1,47 @@
+package e2pg
+
+import "github.com/indexsupply/x/pgmig"
+
+var Migrations = map[int]pgmig.Migration{
+	0: pgmig.Migration{
+		SQL: `
+			create table task (
+				id smallint not null,
+				number bigint,
+				hash bytea,
+				insert_at timestamptz default now()
+			);
+			create table nft_transfers (
+				contract bytea,
+				token_id numeric,
+				quantity numeric,
+				f bytea,
+				t bytea,
+				tx_sender bytea,
+				eth numeric,
+				task_id numeric,
+				chain_id numeric,
+				block_hash bytea,
+				block_number numeric,
+				transaction_hash bytea,
+				transaction_index numeric,
+				log_index numeric
+			);
+			create table erc20_transfers (
+				contract bytea,
+				f bytea,
+				t bytea,
+				value numeric,
+				tx_sender bytea,
+				eth numeric,
+				task_id numeric,
+				chain_id numeric,
+				block_hash bytea,
+				block_number numeric,
+				transaction_hash bytea,
+				transaction_index numeric,
+				log_index numeric
+			);
+		`,
+	},
+}

--- a/e2pg/schema.sql
+++ b/e2pg/schema.sql
@@ -1,39 +1,78 @@
-CREATE TABLE task (
-	id smallint not null,
-	number bigint,
-	hash bytea,
-	insert_at timestamptz default now()
+
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+
+CREATE TABLE public.e2pg_migrations (
+    idx integer NOT NULL,
+    hash bytea NOT NULL,
+    inserted_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
-CREATE UNLOGGED TABLE nft_transfers (
-	contract bytea,
-	token_id numeric,
-	quantity numeric,
-	f bytea,
-	t bytea,
-	tx_sender bytea,
-	eth numeric,
-	task_id numeric,
-	chain_id numeric,
-	block_hash bytea,
-	block_number numeric,
-	transaction_hash bytea,
-	transaction_index numeric,
-	log_index numeric
+
+
+CREATE TABLE public.erc20_transfers (
+    contract bytea,
+    f bytea,
+    t bytea,
+    value numeric,
+    tx_sender bytea,
+    eth numeric,
+    task_id numeric,
+    chain_id numeric,
+    block_hash bytea,
+    block_number numeric,
+    transaction_hash bytea,
+    transaction_index numeric,
+    log_index numeric
 );
 
-CREATE UNLOGGED TABLE erc20_transfers (
-	contract bytea,
-	f bytea,
-	t bytea,
-	value numeric,
-	tx_sender bytea,
-	eth numeric,
-	task_id numeric,
-	chain_id numeric,
-	block_hash bytea,
-	block_number numeric,
-	transaction_hash bytea,
-	transaction_index numeric,
-	log_index numeric
+
+
+CREATE TABLE public.nft_transfers (
+    contract bytea,
+    token_id numeric,
+    quantity numeric,
+    f bytea,
+    t bytea,
+    tx_sender bytea,
+    eth numeric,
+    task_id numeric,
+    chain_id numeric,
+    block_hash bytea,
+    block_number numeric,
+    transaction_hash bytea,
+    transaction_index numeric,
+    log_index numeric
 );
+
+
+
+CREATE TABLE public.task (
+    id smallint NOT NULL,
+    number bigint,
+    hash bytea,
+    insert_at timestamp with time zone DEFAULT now()
+);
+
+
+
+ALTER TABLE ONLY public.e2pg_migrations
+    ADD CONSTRAINT e2pg_migrations_pkey PRIMARY KEY (idx, hash);
+
+
+
+

--- a/pgmig/migrate.go
+++ b/pgmig/migrate.go
@@ -1,0 +1,142 @@
+// migration system for E2PG
+package pgmig
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Migration struct {
+	SQL string
+	// Some types of DDL cannot run inside a transaction.
+	// EG CREATE INDEX CONCURRENTLY
+	// For these cases callers should disable transactions
+	DisableTX bool
+}
+
+func normalizeSQL(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func (m Migration) Hash() []byte {
+	s := normalizeSQL(m.SQL)
+	h := sha256.Sum256([]byte(s))
+	return h[:]
+}
+
+type execer interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+type Migrations map[int]Migration
+
+// Runs the set of migrations (migs) against the database (pgp)
+//
+// migs is a map because the keys represent the order of migrations
+// and so they should be unique. They keys are written to the idx
+// columne of the e2pg_migrations table.
+//
+// The e2pg_migrations table will be created if it doesn't
+// already exist.
+//
+// Migrate will use pg_try_advisory_lock to ensure that only
+// one process is migrating the database at a time. An error
+// is returned if another process has the lock.
+func Migrate(pgp *pgxpool.Pool, migs Migrations) error {
+	ctx := context.Background()
+	// crc32(migrate) == -1924339791
+	var locked bool
+	err := pgp.QueryRow(ctx, `select pg_try_advisory_lock(-1924339791)`).Scan(&locked)
+	if err != nil || !locked {
+		return fmt.Errorf("locking db for migrations: %w", err)
+	}
+
+	const q1 = `
+		create table if not exists e2pg_migrations (
+			idx int not null,
+			hash bytea not null,
+			inserted_at timestamptz default now() not null,
+			primary key (idx, hash)
+		);
+	`
+	_, err = pgp.Exec(ctx, q1)
+	if err != nil {
+		return fmt.Errorf("creating migrations table: %w", err)
+	}
+
+	var keys []int
+	for k, _ := range migs {
+		keys = append(keys, int(k))
+	}
+	sort.Ints(keys)
+
+	for _, i := range keys {
+		var (
+			db   execer = pgp
+			dbtx pgx.Tx
+		)
+		if !migs[i].DisableTX {
+			dbtx, err = pgp.Begin(ctx)
+			if err != nil {
+				return fmt.Errorf("opening a tx: %w", err)
+			}
+			defer dbtx.Rollback(ctx)
+			db = dbtx
+		}
+		ok, err := exists(ctx, db, i, migs[i])
+		if err != nil {
+			return fmt.Errorf("checking migration existence: %w", err)
+		}
+		if ok {
+			continue
+		}
+		err = migrate(ctx, db, i, migs[i])
+		if err != nil {
+			return fmt.Errorf("running migration: %w", err)
+		}
+		if !migs[i].DisableTX {
+			err = dbtx.Commit(ctx)
+			if err != nil {
+				return fmt.Errorf("commiting migration tx: %w", err)
+			}
+		}
+		h := migs[i].Hash()
+		fmt.Printf("migrated %d %x\n", i, h[:4])
+	}
+	return nil
+}
+
+func migrate(ctx context.Context, db execer, i int, m Migration) error {
+	_, err := db.Exec(ctx, m.SQL)
+	if err != nil {
+		return fmt.Errorf("migration %d %x exec error: %w", i, m.Hash(), err)
+	}
+	const q = `insert into e2pg_migrations(idx, hash) values ($1, $2)`
+	_, err = db.Exec(ctx, q, i, m.Hash())
+	if err != nil {
+		return fmt.Errorf("migrations table %d %x insert error: %w", i, m.Hash(), err)
+	}
+	return nil
+}
+
+func exists(ctx context.Context, db execer, i int, m Migration) (bool, error) {
+	const q = `select true from e2pg_migrations where idx = $1 and hash = $2`
+	var found bool
+	err := db.QueryRow(ctx, q, i, m.Hash()).Scan(&found)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("querying for existing migration: %w", err)
+	}
+	return found, nil
+}

--- a/pgmig/migrate_test.go
+++ b/pgmig/migrate_test.go
@@ -1,0 +1,129 @@
+package pgmig
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"blake.io/pqx/pqxtest"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"kr.dev/diff"
+)
+
+func TestMain(m *testing.M) {
+	sql.Register("postgres", stdlib.GetDefaultDriver())
+	pqxtest.TestMain(m)
+}
+
+func TestMigrateLock(t *testing.T) {
+	pqxtest.CreateDB(t, "")
+	pg, err := pgxpool.New(context.Background(), pqxtest.DSNForTest(t))
+	diff.Test(t, t.Fatalf, err, nil)
+	wait := make(chan error)
+	go func() {
+		wait <- Migrate(pg, Migrations{0: Migration{SQL: "select pg_sleep(5)"}})
+	}()
+	go func() {
+		wait <- Migrate(pg, Migrations{0: Migration{SQL: "select pg_sleep(5)"}})
+	}()
+	err = <-wait
+	if err == nil {
+		t.Fatal("expected lock error")
+	}
+	if !strings.Contains(err.Error(), "locking db for migrations") {
+		t.Fatalf("expected lock error. got: %s", err)
+	}
+}
+
+func TestMigrate(t *testing.T) {
+	ctx := context.Background()
+	pqxtest.CreateDB(t, "")
+	pg, err := pgxpool.New(ctx, pqxtest.DSNForTest(t))
+	diff.Test(t, t.Fatalf, err, nil)
+
+	reset := func() {
+		if _, err := pg.Exec(ctx, "drop schema public cascade"); err != nil {
+			t.Fatalf("dropping schema: %s", err)
+		}
+		if _, err := pg.Exec(ctx, "create schema public"); err != nil {
+			t.Fatalf("dropping schema: %s", err)
+		}
+	}
+
+	cases := []struct {
+		migs     Migrations
+		check    string
+		errCheck func(error) bool
+	}{
+		{
+			migs: Migrations{
+				0: Migration{
+					SQL: "create table x(id int)",
+				},
+			},
+			check:    `select true from pg_tables where tablename = 'x'`,
+			errCheck: nil,
+		},
+		{
+			migs: Migrations{
+				0: Migration{
+					SQL: "create table x(id int)",
+				},
+				1: Migration{
+					SQL: "create table x(id int)",
+				},
+			},
+			check: `select true from pg_tables where tablename = 'x'`,
+			errCheck: func(err error) bool {
+				return strings.Contains(err.Error(), `"x" already exists`)
+			},
+		},
+		{
+			migs: Migrations{
+				0: Migration{
+					SQL: "create table t(x int)",
+				},
+				1: Migration{
+					SQL: "create index concurrently on t(x)",
+				},
+			},
+			errCheck: func(err error) bool {
+				msg := `CREATE INDEX CONCURRENTLY cannot run inside a transaction block`
+				return strings.Contains(err.Error(), msg)
+			},
+		},
+		{
+			migs: Migrations{
+				0: Migration{
+					SQL: "create table t(x int)",
+				},
+				1: Migration{
+					DisableTX: true,
+					SQL:       "create index concurrently on t(x)",
+				},
+			},
+			errCheck: nil,
+		},
+	}
+	for _, tc := range cases {
+		reset()
+		switch err := Migrate(pg, tc.migs); {
+		case tc.errCheck == nil:
+			if err != nil {
+				t.Errorf("expected err to be nil. got: %s", err)
+			}
+		default:
+			if !tc.errCheck(err) {
+				t.Errorf("unexpected error: %s", err)
+			}
+		}
+
+		if tc.check != "" {
+			var check bool
+			err = pg.QueryRow(ctx, tc.check).Scan(&check)
+			diff.Test(t, t.Fatalf, err, nil)
+		}
+	}
+}


### PR DESCRIPTION
Adds a file at e2pg/migrations.go which holds all of E2PG's migrations.
The e2pg/schema.sql file is now generated from the migrations file via
the dumpschema command.

Users should call dumpschema after adding a migration to the migrations
file. If this doesn't happen the the GH action test will likely fail.

Migrations can be skipped using the -skip-migration E2PG flag.