### PR TITLE
e2pg: Fix dashboard crash on high latency

### DIFF
--- a/e2pg/e2pg.go
+++ b/e2pg/e2pg.go
@@ -166,9 +166,17 @@ func (task *Task) Status() StatusSnapshot {
 	printer := message.NewPrinter(message.MatchLanguage("en"))
 	snap := StatusSnapshot{}
 	snap.Name = task.Name
-	snap.EthHash = fmt.Sprintf("%x", task.stat.ehash[:4])
+	if len(task.stat.ehash) == 0 {
+		snap.EthHash = "-";
+	} else {
+		snap.EthHash = fmt.Sprintf("%x", task.stat.ehash[:4])
+	}
 	snap.EthNum = fmt.Sprintf("%d", task.stat.enum)
-	snap.Hash = fmt.Sprintf("%x", task.stat.ihash[:4])
+	if len(task.stat.ihash) == 0 {
+		snap.Hash = "-";
+	} else {
+		snap.Hash = fmt.Sprintf("%x", task.stat.ihash[:4])
+	}
 	snap.Num = printer.Sprintf("%d", task.stat.inum)
 	snap.BlockCount = fmt.Sprintf("%d", atomic.SwapInt64(&task.stat.blocks, 0))
 	snap.EventCount = fmt.Sprintf("%d", atomic.SwapInt64(&task.stat.events, 0))


### PR DESCRIPTION
The dashboard render crashes if the RLPS server has too high latency and task doesn't have any block yet. Fix by adding a fallback in that case.

<strike>Based on #143, will rebase on master once that's merged.</strike> Ready for review.

<img width="682" alt="image" src="https://github.com/indexsupply/x/assets/6984346/1be829da-ec65-4df6-9840-e05f6ae37d78">
