### PR TITLE
e2pg/migrations: remove nft_transfers unique constraint

### DIFF
--- a/e2pg/migrations.go
+++ b/e2pg/migrations.go
@@ -83,4 +83,7 @@ var Migrations = map[int]pgmig.Migration{
 			unique (chain_id, transaction_hash, log_index);
 		`,
 	},
+	3: pgmig.Migration{
+		SQL: `alter table nft_transfers drop constraint nft_transfers_unique;`,
+	},
 }


### PR DESCRIPTION
Unfortunately this constraint isn't valid because erc1155 transfers can result in multiple rows being created for a single tx/log.