### PR TITLE
e2pg: copy data into core structs instead of copying pointers

### DIFF
--- a/cmd/e2pg/main.go
+++ b/cmd/e2pg/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	npprof "net/http/pprof"
 	"os"
 	"runtime/debug"
 	"runtime/pprof"
@@ -16,9 +17,9 @@ import (
 	"github.com/indexsupply/x/e2pg"
 	"github.com/indexsupply/x/e2pg/config"
 	"github.com/indexsupply/x/pgmig"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
 )
 
 func check(err error) {
@@ -110,7 +111,12 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", dh.Index)
 	mux.HandleFunc("/updates", dh.Updates)
-	mux.HandleFunc("/debug/pprof/profile", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/debug/pprof/", npprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", npprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", npprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", npprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", npprof.Trace)
+	mux.HandleFunc("/debug/pprof/capture", func(w http.ResponseWriter, r *http.Request) {
 		w.Write(pbuf.Bytes())
 	})
 	go http.ListenAndServe(listen, mux)


### PR DESCRIPTION
The core structs (ie Header, Transaction, Receipt) had a mix of owned and borrowed data. The byte slices were pointers to data that were allocated lower in the stack while the uint64s were allocated within the struct. I am exploring moving to a model where instead of keeping long lived buffers in the lower parts of the stack, we use temporary buffers and copy the data into the core structs. This means that we can more easily tune allocations lower in the stack because they don't need to worry about keeping the data around after they've done their job.

Finally, this change actually fixes a memory leak when e2pg is connected to RLPS. Since rlps.LoadBlocks uses io.ReadAll it would allocate the byte slice and then assign pointers to the byte slice onto the core structs. This meant that the io.ReadAll slice would hang around in memory. One option was to keep a byte slice around and use io.Copy instead of io.ReadAll, but that require extra bookkeeping -- bookkeeping that the GC may already be doing. By copying data from the slice into the core structs, the GC will recognize that the byte slice from io.ReadAll is no longer used and therefore it will get cleaned up.