### PR TITLE
rlps: client sends hash to avoid cached reorg blocks

### DIFF
--- a/rlps/rlps.go
+++ b/rlps/rlps.go
@@ -35,12 +35,19 @@ type Client struct {
 var bufferPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
 func (c *Client) LoadBlocks(filter [][]byte, bfs []geth.Buffer, blocks []e2pg.Block) error {
+	// Use hash in the request url to avoid having the
+	// rlps cdn serve a reorganized block.
+	h, err := c.Hash(bfs[0].Number)
+	if err != nil {
+		return fmt.Errorf("unable to get hash for %d: %w", bfs[0].Number, err)
+	}
 	u, err := url.Parse(c.surl + "/blocks")
 	if err != nil {
 		return fmt.Errorf("unable to parse rpls server url")
 	}
 	q := u.Query()
 	q.Add("n", strconv.FormatUint(bfs[0].Number, 10))
+	q.Add("h", hex.EncodeToString(h))
 	q.Add("limit", strconv.Itoa(len(blocks)))
 	q.Add("filter", unparseFilter(filter))
 	u.RawQuery = q.Encode()


### PR DESCRIPTION
As of today the CDN doesn't cache data since it's likely to serve invalid data in the case of a reorg.

The scenario:

	E2PG has block {n:1 hash:a parent:z} and then requests block {n:2}.
	E2PG requests {n:2}
	E2PG stores block {n:2 hash:b parent:a}
	Eth reorgs and {n:2} becomes {n:2 hash:c parent:a}
	E2PG deletes {n:2 hash:b parent:a}
	E2PG requests {n:2}

At this point the CDN will serve: `{n:2 hash:b parent:a}`

The fix:

	E2PG has block {n:1 hash:a parent:z} and then requests block {n:2}.
	E2PG requests hash for {n:2}
	E2PG requests {n:2 hash:b}
	E2PG stores block {n:2 hash:b parent:a}
	Eth reorgs and {n:2} becomes {n:2 hash:c parent:a}
	E2PG deletes {n:2 hash:b parent:a}
	E2PG requests hash for {n:2}
	E2PG requests {n:2 hash:c}
	E2PG stores block {n:2 hash:c parent:a}

The RLPS server code will ignore this value. It's only used as a cache key for the CDN. Maybe later we can use this value to futher optimize the server read path.

Eventually I need to enable caching on the CDN. For clients who aren't running this code, and in the case or a reorg, their clients will be stuck until they update to this commit. In other words: BREAKING CHANGE