### PR TITLE
e2pg: use block number for reorg instead of hash

### DIFF
--- a/e2pg/e2pg_test.go
+++ b/e2pg/e2pg_test.go
@@ -24,12 +24,12 @@ func TestMain(m *testing.M) {
 
 type testIntegration struct {
 	sync.Mutex
-	chain map[string]Block
+	chain map[uint64]Block
 }
 
 func newTestIntegration() *testIntegration {
 	return &testIntegration{
-		chain: make(map[string]Block),
+		chain: make(map[uint64]Block),
 	}
 }
 
@@ -48,7 +48,7 @@ func (ti *testIntegration) Insert(_ context.Context, _ PG, blocks []Block) (int6
 	ti.Lock()
 	defer ti.Unlock()
 	for _, b := range blocks {
-		ti.chain[fmt.Sprintf("%x", b.Hash())] = b
+		ti.chain[b.Header.Number] = b
 	}
 	return int64(len(blocks)), nil
 }
@@ -65,10 +65,10 @@ func (ti *testIntegration) add(n uint64, hash, parent []byte) {
 	})
 }
 
-func (ti *testIntegration) Delete(_ context.Context, pg PG, h []byte) error {
+func (ti *testIntegration) Delete(_ context.Context, pg PG, n uint64) error {
 	ti.Lock()
 	defer ti.Unlock()
-	delete(ti.chain, fmt.Sprintf("%x", h))
+	delete(ti.chain, n)
 	return nil
 }
 

--- a/integrations/erc1155/transfer.go
+++ b/integrations/erc1155/transfer.go
@@ -17,8 +17,15 @@ var Integration = integration{
 	name: "ERC1155 Transfer",
 }
 
-func (i integration) Delete(ctx context.Context, pg e2pg.PG, h []byte) error {
-	return nil
+func (i integration) Delete(ctx context.Context, pg e2pg.PG, n uint64) error {
+	const q = `
+		delete from nft_transfers
+		where task_id = $1
+		and chain_id = $2
+		and block_number >= $3
+	`
+	_, err := pg.Exec(ctx, q, e2pg.TaskID(ctx), e2pg.ChainID(ctx), n)
+	return err
 }
 
 func (i integration) Events(ctx context.Context) [][]byte {

--- a/integrations/erc20/transfer.go
+++ b/integrations/erc20/transfer.go
@@ -30,14 +30,14 @@ func (i integration) Events(ctx context.Context) [][]byte {
 	return [][]byte{sigHash}
 }
 
-func (i integration) Delete(ctx context.Context, pg e2pg.PG, h []byte) error {
+func (i integration) Delete(ctx context.Context, pg e2pg.PG, n uint64) error {
 	const q = `
 		delete from erc20_transfers
 		where task_id = $1
 		and chain_id = $2
-		and block_hash = $3
+		and block_number >= $3
 	`
-	_, err := pg.Exec(ctx, q, e2pg.TaskID(ctx), e2pg.ChainID(ctx), h)
+	_, err := pg.Exec(ctx, q, e2pg.TaskID(ctx), e2pg.ChainID(ctx), n)
 	return err
 }
 

--- a/integrations/erc4337/userop.go
+++ b/integrations/erc4337/userop.go
@@ -21,14 +21,14 @@ func (i integration) Events(ctx context.Context) [][]byte {
 	return [][]byte{erc4337.UserOperationEventSignatureHash}
 }
 
-func (i integration) Delete(ctx context.Context, pg e2pg.PG, h []byte) error {
+func (i integration) Delete(ctx context.Context, pg e2pg.PG, n uint64) error {
 	const q = `
 		delete from erc4337_userops
 		where task_id = $1
 		and chain_id = $2
-		and block_hash = $3
+		and block_number >= $3
 	`
-	_, err := pg.Exec(ctx, q, e2pg.TaskID(ctx), e2pg.ChainID(ctx), h)
+	_, err := pg.Exec(ctx, q, e2pg.TaskID(ctx), e2pg.ChainID(ctx), n)
 	return err
 }
 

--- a/integrations/erc721/transfer.go
+++ b/integrations/erc721/transfer.go
@@ -17,8 +17,15 @@ var Integration = integration{
 	name: "ERC721 Transfer",
 }
 
-func (i integration) Delete(ctx context.Context, pg e2pg.PG, h []byte) error {
-	return nil
+func (i integration) Delete(ctx context.Context, pg e2pg.PG, n uint64) error {
+	const q = `
+		delete from nft_transfers
+		where task_id = $1
+		and chain_id = $2
+		and block_number >= $3
+	`
+	_, err := pg.Exec(ctx, q, e2pg.TaskID(ctx), e2pg.ChainID(ctx), n)
+	return err
 }
 
 func (i integration) Events(ctx context.Context) [][]byte {


### PR DESCRIPTION
When a task indexes a batch of blocks it records the highest block number in the task table. If a block within a batch is removed via reorg then it is possible for integrations to contain rows relating to a block that isn't present in the task table. In this case the integrations rows are never removed.

To address this problem, the integrations will now receive a block height that is to be removed and the integrations will delete all rows above and including that block height.