### PR TITLE
cmd/{rlpq,keccak}: new commands for debugging rlps

### DIFF
--- a/cmd/keccak/main.go
+++ b/cmd/keccak/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/indexsupply/x/isxhash"
+)
+
+func main() {
+	switch len(os.Args) {
+	case 1:
+		input, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		b, err := hex.DecodeString(string(input[:len(input)-1]))
+		if err != nil {
+			fmt.Println("unable to hex decode stdin")
+			os.Exit(1)
+		}
+		fmt.Printf("%x\n", isxhash.Keccak(b))
+	case 2:
+		b, err := hex.DecodeString(os.Args[1])
+		if err != nil {
+			fmt.Println("unable to hex decode argument")
+			os.Exit(1)
+		}
+		fmt.Printf("%x\n", isxhash.Keccak(b))
+	default:
+		fmt.Printf("keccak reads from stdin or through first argument")
+	}
+}

--- a/cmd/rlpq/main.go
+++ b/cmd/rlpq/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/indexsupply/x/rlp"
+)
+
+func check(err error) {
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	var (
+		chain   uint64
+		block   uint64
+		txidx   int
+		receipt bool
+	)
+	flag.Uint64Var(&chain, "c", 1, "chain id")
+	flag.Uint64Var(&block, "b", 1, "block number")
+	flag.IntVar(&txidx, "t", -1, "transaction index")
+	flag.BoolVar(&receipt, "r", false, "receipt")
+	flag.Parse()
+
+	u, err := url.Parse(fmt.Sprintf("https://%d.rlps.indexsupply.net/blocks", chain))
+	check(err)
+
+	q := u.Query()
+	q.Add("n", strconv.FormatUint(block, 10))
+	q.Add("limit", "1")
+	u.RawQuery = q.Encode()
+
+	resp, err := http.Get(u.String())
+	check(err)
+	buf, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	check(err)
+	if (resp.StatusCode / 100) != 2 {
+		check(fmt.Errorf("rlps error: %s", string(buf)))
+	}
+
+	for i, bitr := 0, rlp.Iter(buf); bitr.HasNext(); i++ {
+		var (
+			blockRLP    = rlp.Iter(bitr.Bytes())
+			headerRLP   = blockRLP.Bytes()
+			bodiesRLP   = blockRLP.Bytes()
+			receiptsRLP = blockRLP.Bytes()
+		)
+		switch {
+		case txidx < 0:
+			fmt.Printf("%x\n", headerRLP)
+		case !receipt && txidx > 0:
+			for j, it := 0, rlp.Iter(rlp.Bytes(bodiesRLP)); it.HasNext(); j++ {
+				tx := it.Bytes()
+				if j == txidx {
+					fmt.Printf("%x\n", tx)
+				}
+			}
+		case receipt && txidx < 0:
+			fmt.Println("must specify -t for receipt")
+		case receipt && txidx > 0:
+			fmt.Printf("%x\n", receiptsRLP)
+			for j, it := 0, rlp.Iter(bodiesRLP); it.HasNext(); j++ {
+				r := it.Bytes()
+				if j == txidx {
+					fmt.Printf("%x\n", r)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
RLPQ returns RLP encoded data for: headers, bodies, and receipts. Keccak will hash the stdin/arg

Query a block hash
```
% rlpq -c 1 -b 17921490  | keccak                       
17a3ea106158267e8d0fae90e8f6810af9e2e380ec11a832318f35754ae820a5
```

Query a transaction hash
```
% rlpq -c 1 -b 17921490  -t 120 | keccak
394405d436baad9d6f5f3d51763bab688322d2da5ca0afd0293754e2986f4d14
```

Query a transaction receipt
```
% rlpq -c 1 -b 17921490  -t 120 -r         
f9fd81f9095a018...
```