### PR TITLE
e2pg: use pg_advisory_lock to limit 1 process per task

### DIFF
--- a/cmd/e2pg/main.go
+++ b/cmd/e2pg/main.go
@@ -129,6 +129,7 @@ func main() {
 	for i := range tasks {
 		i := i
 		eg.Go(func() error {
+			check(tasks[i].Ready())
 			check(tasks[i].Setup())
 			check(tasks[i].Run(snaps, notx))
 			return nil

--- a/e2pg/e2pg.go
+++ b/e2pg/e2pg.go
@@ -208,6 +208,16 @@ func (task *Task) Latest() (uint64, []byte, error) {
 	return n, h, err
 }
 
+func (task *Task) Ready() error {
+	//crc32(task) == 1384045349
+	const q = `select pg_advisory_lock(1384045349, $1)`
+	_, err := task.pgp.Exec(context.Background(), q, task.ID)
+	if err != nil {
+		return fmt.Errorf("waiting for task lock %d: %w", task.ID, err)
+	}
+	return nil
+}
+
 func (task *Task) Setup() error {
 	_, localHash, err := task.Latest()
 	if err != nil {


### PR DESCRIPTION
Deploys, or operational errors, can lead to multiple E2PG processes running at a single time. This causes duplicated work but because of the databases unique constraints there are no corruption issues. However, it is best to avoid these duplication errors as it can be confusing to deployment tooling and its operator.

Fixes #151