### PR TITLE
e2pg/migrations: create index on task table

### DIFF
--- a/e2pg/migrations.go
+++ b/e2pg/migrations.go
@@ -93,4 +93,7 @@ var Migrations = map[int]pgmig.Migration{
 			alter table erc20_transfers rename column tx_sender to tx_signer;
 		`,
 	},
+	5: pgmig.Migration{
+		SQL: "create index on task(id, number desc);",
+	},
 }

--- a/e2pg/schema.sql
+++ b/e2pg/schema.sql
@@ -107,4 +107,8 @@ ALTER TABLE ONLY public.erc4337_userops
 
 
 
+CREATE INDEX task_id_number_idx ON public.task USING btree (id, number DESC);
+
+
+
 


### PR DESCRIPTION
We specify an order on number since our primary query on this table uses a ORDER BY number LIMIT 1 statement. This means that the relation should not need to be sorted at query time.