### PR TITLE
e2pg: use stable task id

### DIFF
--- a/abi2/abi2.go
+++ b/abi2/abi2.go
@@ -696,6 +696,8 @@ type logWithCtx struct {
 
 func (lwc *logWithCtx) get(name string) any {
 	switch name {
+	case "task_id":
+		return e2pg.TaskID(lwc.ctx)
 	case "chain_id":
 		return e2pg.ChainID(lwc.ctx)
 	case "block_hash":
@@ -772,7 +774,7 @@ func (ig Integration) processLog(rows [][]any, lwc *logWithCtx) ([][]any, error)
 					row[j] = dbtype(def.Input.Type, d)
 					ictr++
 				case !def.BlockData.Empty():
-					d := lwc.get(def.Column.Name)
+					d := lwc.get(def.BlockData.Name)
 					if b, ok := d.([]byte); ok && !def.BlockData.Accept(b) {
 						return rows, nil
 					}

--- a/cmd/e2pg/dashboard.go
+++ b/cmd/e2pg/dashboard.go
@@ -122,9 +122,9 @@ func (dh *dashHandler) Index(w http.ResponseWriter, r *http.Request) {
 							{{ range $id, $status := . -}}
 							{{ $name := $status.Name -}}
 							<tr>
-								<td id="{{ printf "%s-name" $name}}">{{ $name }}</td>
+								<td id="{{ printf "%s-name" $name}}" style="text-transform: capitalize">{{ $name }}</td>
 								<td id="{{ printf "%s-id" $name}}">{{ $id }}</td>
-								<td id="{{ printf "%s-num" $name}}">{{ $status.Num }}</td>
+								<td id="{{ printf "%s-num" $name}}" style="text-align: right">{{ $status.Num }}</td>
 								<td id="{{ printf "%s-hash" $name}}">{{ $status.Hash }}</td>
 								<td id="{{ printf "%s-block_count" $name}}">{{ $status.BlockCount }}</td>
 								<td id="{{ printf "%s-event_count" $name}}">{{ $status.EventCount }}</td>
@@ -164,7 +164,8 @@ func (dh *dashHandler) Index(w http.ResponseWriter, r *http.Request) {
 	}
 	snaps := make(map[uint64]e2pg.StatusSnapshot)
 	for _, task := range dh.tasks {
-		snaps[task.ID] = task.Status()
+		s := task.Status()
+		snaps[s.ChainID] = s
 	}
 	err = tmpl.Execute(w, snaps)
 	if err != nil {

--- a/cmd/e2pg/main.go
+++ b/cmd/e2pg/main.go
@@ -62,10 +62,10 @@ func main() {
 	})
 	lh.RegisterContext(func(ctx context.Context) (string, any) {
 		id := e2pg.TaskID(ctx)
-		if id < 1 {
+		if id == "" {
 			return "", nil
 		}
-		return "task", fmt.Sprintf("%.2d", id)
+		return "task", id
 	})
 	slog.SetDefault(slog.New(lh.WithAttrs([]slog.Attr{
 		slog.Int("p", os.Getpid()),

--- a/e2pg/config/integration_test.go
+++ b/e2pg/config/integration_test.go
@@ -42,6 +42,7 @@ func TestIntegrations(t *testing.T) {
 				`
 				select count(*) = 4 from erc721_test
 				where tx_hash = '\x713df81a2ab53db1d01531106fc5de43012a401ddc3e0586d522e5c55a162d42'
+				and contract = '\x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85'
 				`,
 			},
 		},

--- a/e2pg/config/testdata/erc721.json
+++ b/e2pg/config/testdata/erc721.json
@@ -6,6 +6,7 @@
 			{"name": "chain_id", "type": "numeric"},
 			{"name": "block_num", "type": "numeric"},
 			{"name": "tx_hash", "type": "bytea"},
+			{"name": "contract", "type": "bytea"},
 			{"name": "f", "type": "bytea"},
 			{"name": "t", "type": "bytea"},
 			{"name": "token", "type": "numeric"}
@@ -14,6 +15,7 @@
 	"block": [
 		{"name": "chain_id", "column": "chain_id"},
 		{"name": "block_num", "column": "block_num"},
+		{"name": "log_addr", "column": "contract"},
 		{"name": "tx_hash", "column": "tx_hash", "filter_op": "contains", "filter_arg": ["713df81a2ab53db1d01531106fc5de43012a401ddc3e0586d522e5c55a162d42"]}
 	],
 	"event": {

--- a/e2pg/migrations.go
+++ b/e2pg/migrations.go
@@ -114,4 +114,13 @@ var Migrations = map[int]pgmig.Migration{
 			)
 		`,
 	},
+	8: pgmig.Migration{
+		SQL: `
+			alter table e2pg.task alter column id type text;
+			alter table nft_transfers alter column task_id type text;
+			alter table erc20_transfers alter column task_id type text;
+			alter table erc4337_userops alter column task_id type text;
+			alter table tx_inputs alter column task_id type text;
+		`,
+	},
 }

--- a/e2pg/schema.sql
+++ b/e2pg/schema.sql
@@ -29,7 +29,7 @@ CREATE TABLE e2pg.migrations (
 
 
 CREATE TABLE e2pg.task (
-    id smallint NOT NULL,
+    id text NOT NULL,
     number bigint,
     hash bytea,
     insert_at timestamp with time zone DEFAULT now()
@@ -44,7 +44,7 @@ CREATE TABLE public.erc20_transfers (
     value numeric,
     tx_signer bytea,
     eth numeric,
-    task_id numeric,
+    task_id text,
     chain_id numeric,
     block_hash bytea,
     block_number numeric,
@@ -66,7 +66,7 @@ CREATE TABLE public.erc4337_userops (
     op_actual_gas_used numeric,
     tx_signer bytea,
     eth numeric,
-    task_id numeric,
+    task_id text,
     chain_id numeric,
     block_hash bytea,
     block_number numeric,
@@ -85,7 +85,7 @@ CREATE TABLE public.nft_transfers (
     t bytea,
     tx_signer bytea,
     eth numeric,
-    task_id numeric,
+    task_id text,
     chain_id numeric,
     block_hash bytea,
     block_number numeric,
@@ -97,7 +97,7 @@ CREATE TABLE public.nft_transfers (
 
 
 CREATE TABLE public.tx_inputs (
-    task_id numeric,
+    task_id text,
     chain_id numeric,
     block_hash bytea,
     block_number numeric,

--- a/integrations/testhelper/helper.go
+++ b/integrations/testhelper/helper.go
@@ -66,7 +66,11 @@ func (th *H) Done() {
 func (th *H) Process(ig e2pg.Integration, n uint64) {
 	var (
 		geth = e2pg.NewGeth(th.gt.FileCache, th.gt.Client)
-		task = e2pg.NewTask(0, 0, "main", 1, 1, geth, th.PG, 0, 0, ig)
+		task = e2pg.NewTask(
+			e2pg.WithNode(geth),
+			e2pg.WithPG(th.PG),
+			e2pg.WithIntegrations(ig),
+		)
 	)
 	cur, err := geth.Hash(n)
 	check(th.tb, err)

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -18,19 +18,23 @@ import (
 	"github.com/indexsupply/x/geth"
 )
 
-func New(url string) *Client {
+func New(chainID uint64, url string) *Client {
 	return &Client{
-		d:   strings.Contains(url, "debug"),
-		hc:  &http.Client{},
-		url: url,
+		chainID: chainID,
+		d:       strings.Contains(url, "debug"),
+		hc:      &http.Client{},
+		url:     url,
 	}
 }
 
 type Client struct {
-	d   bool
-	url string
-	hc  *http.Client
+	d       bool
+	chainID uint64
+	url     string
+	hc      *http.Client
 }
+
+func (c *Client) ChainID() uint64 { return c.chainID }
 
 func (c *Client) debug(r io.Reader) io.Reader {
 	if !c.d {

--- a/jrpc2/client_test.go
+++ b/jrpc2/client_test.go
@@ -36,7 +36,7 @@ func TestLatest(t *testing.T) {
 	defer ts.Close()
 
 	blocks := []eth.Block{eth.Block{Header: eth.Header{Number: 18000000}}}
-	c := New(ts.URL)
+	c := New(0, ts.URL)
 	err := c.LoadBlocks(nil, nil, blocks)
 	diff.Test(t, t.Errorf, nil, err)
 

--- a/rlps/rlps.go
+++ b/rlps/rlps.go
@@ -21,17 +21,21 @@ import (
 	"github.com/indexsupply/x/rlp"
 )
 
-func NewClient(s string) *Client {
+func NewClient(chainID uint64, url string) *Client {
 	return &Client{
-		surl: s,
-		hc:   &http.Client{},
+		chainID: chainID,
+		surl:    url,
+		hc:      &http.Client{},
 	}
 }
 
 type Client struct {
-	surl string
-	hc   *http.Client
+	chainID uint64
+	surl    string
+	hc      *http.Client
 }
+
+func (c *Client) ChainID() uint64 { return c.chainID }
 
 var bufferPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 

--- a/rlps/rlps_test.go
+++ b/rlps/rlps_test.go
@@ -28,7 +28,7 @@ func TestServerErrors(t *testing.T) {
 		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "an error", http.StatusInternalServerError)
 		}))
-		cli = NewClient(ts.URL)
+		cli = NewClient(0, ts.URL)
 	)
 	defer ts.Close()
 	h, err := cli.Hash(16000000)
@@ -58,7 +58,7 @@ func TestHash(t *testing.T) {
 	var (
 		srv = NewServer(gtest.FileCache, gtest.Client)
 		ts  = httptest.NewServer(srv)
-		cli = NewClient(ts.URL)
+		cli = NewClient(0, ts.URL)
 	)
 	defer ts.Close()
 
@@ -75,7 +75,7 @@ func TestLatest(t *testing.T) {
 	var (
 		srv = NewServer(gtest.FileCache, gtest.Client)
 		ts  = httptest.NewServer(srv)
-		cli = NewClient(ts.URL)
+		cli = NewClient(0, ts.URL)
 	)
 	defer ts.Close()
 
@@ -93,7 +93,7 @@ func TestLoadBlocks(t *testing.T) {
 	var (
 		srv = NewServer(gtest.FileCache, gtest.Client)
 		ts  = httptest.NewServer(srv)
-		cli = NewClient(ts.URL)
+		cli = NewClient(0, ts.URL)
 	)
 	defer ts.Close()
 
@@ -124,7 +124,7 @@ func TestLoadBlocks_Filter(t *testing.T) {
 	var (
 		srv = NewServer(gtest.FileCache, gtest.Client)
 		ts  = httptest.NewServer(srv)
-		cli = NewClient(ts.URL)
+		cli = NewClient(0, ts.URL)
 	)
 	defer ts.Close()
 
@@ -148,7 +148,7 @@ func TestLoadBlocks_Filter_Error(t *testing.T) {
 	var (
 		srv = NewServer(gtest.FileCache, gtest.Client)
 		ts  = httptest.NewServer(srv)
-		cli = NewClient(ts.URL)
+		cli = NewClient(0, ts.URL)
 	)
 	defer ts.Close()
 


### PR DESCRIPTION
This is part of a larger change in E2PG. Instead of users defining tasks, E2PG builds tasks based on user configured integrations.

Each chain (defined in the Ethereum Sources field in the config) will have a main task. Integrations that are following the chain will be processed in the main task. If an integration requires a backfill, a new task will be created. Backfills are not a part of this commit and will be added later. Backfills will need to coordinate to not overlap work with the main task.

Given this archetecture, a task id can simple be: the chain id, a string tag that is one of 'main' 'backfill' and an optional backfill string tag that is unique amongst other backfills on the chain. For example:

1-main

1-backfill-foo