### PR TITLE
eth/types: fix json tag on Tx.Value

### DIFF
--- a/eth/types.go
+++ b/eth/types.go
@@ -283,7 +283,7 @@ type Tx struct {
 	GasLimit Uint64      `json:"gas"`
 	From     Bytes       `json:"from"`
 	To       Bytes       `json:"to"`
-	Value    uint256.Int `json:"vlaue"`
+	Value    uint256.Int `json:"value"`
 	Data     Bytes       `json:"input"`
 	V        uint256.Int `json:"v"`
 	R        uint256.Int `json:"r"`


### PR DESCRIPTION
tx.value was not being parsed correctly due to a typo. After putting in this change, tx.value stopped showing up as 0