### PR TITLE
eth: bugfix. ensure Bytes are reset during unmarshal

### DIFF
--- a/eth/types.go
+++ b/eth/types.go
@@ -93,6 +93,7 @@ func (hb *Bytes) UnmarshalJSON(data []byte) error {
 		n := len(data)/2 - len(*hb)
 		*hb = append(*hb, make(Bytes, n)...)
 	}
+	*hb = (*hb)[:len(data)/2]
 	_, err := hex.Decode(*hb, data)
 	return err
 }

--- a/eth/types_test.go
+++ b/eth/types_test.go
@@ -96,6 +96,14 @@ func TestBytes(t *testing.T) {
 	}
 }
 
+func TestBytes_Reuse(t *testing.T) {
+	x := struct{ D Bytes }{}
+	json.Unmarshal([]byte(`{"D": "0xdeadbeef"}`), &x)
+	diff.Test(t, t.Errorf, h2b("deadbeef"), x.D.Bytes())
+	json.Unmarshal([]byte(`{"D": "0xde"}`), &x)
+	diff.Test(t, t.Errorf, h2b("de"), x.D.Bytes())
+}
+
 func TestBytes_Write(t *testing.T) {
 	var x Bytes
 	diff.Test(t, t.Errorf, 0, len(x))


### PR DESCRIPTION
Since the Tx is reused during batch processing, it's possible for the value to accumulate data from prior use. The Bytes.Write function correctly resized the underlying slice prior to decoding but the UnmarshalJSON did not. Now it does.