### PR TITLE
abi2: op_filter 'contains' to use bytes.Contains instead of bytes.Equal

### DIFF
--- a/abi2/abi2.go
+++ b/abi2/abi2.go
@@ -378,7 +378,7 @@ func (f Filter) Accept(d []byte) bool {
 		var res bool
 		for i := range f.Arg {
 			hb, _ := hex.DecodeString(f.Arg[i])
-			if bytes.Equal(hb, d) {
+			if bytes.Contains(d, hb) {
 				res = true
 				break
 			}


### PR DESCRIPTION
Right now the code checks for exact matches, it would be better to check for partial matches