### PR TITLE
Remove unused Integration fields + Add block.timestamp parsing

### DIFF
--- a/abi2/abi2.go
+++ b/abi2/abi2.go
@@ -701,6 +701,8 @@ func (lwc *logWithCtx) get(name string) any {
 		return lwc.b.Hash()
 	case "block_num":
 		return lwc.b.Num()
+	case "block_timestamp":
+		return lwc.b.Header.Time
 	case "tx_hash":
 		return lwc.t.Hash()
 	case "tx_idx":

--- a/e2pg/e2pg.go
+++ b/e2pg/e2pg.go
@@ -709,9 +709,6 @@ type Compiled struct {
 type Integration struct {
 	Name          string           `json:"name"`
 	Enabled       bool             `json:"enabled"`
-	Start         string           `json:"start"`
-	Stop          string           `json:"stop"`
-	Backfill      bool             `json:"backfill"`
 	SourceConfigs []SourceConfig   `json:"sources"`
 	Table         abi2.Table       `json:"table"`
 	Compiled      Compiled         `json:"compiled"`


### PR DESCRIPTION
These fields are no longer used - removing them to make the code clearer.

Also added block timestamp support since it's already being fetched as part of the block header