### PR TITLE
e2pg: remove task id

### DIFF
--- a/abi2/abi2.go
+++ b/abi2/abi2.go
@@ -649,7 +649,7 @@ func (ig Integration) Insert(ctx context.Context, pg wpg.Conn, blocks []eth.Bloc
 		err  error
 		skip bool
 		rows [][]any
-		lwc  = &logWithCtx{ctx: ctx}
+		lwc  = &logWithCtx{ctx: wctx.WithIntgName(ctx, ig.Name())}
 	)
 	for bidx := range blocks {
 		lwc.b = &blocks[bidx]
@@ -693,8 +693,10 @@ type logWithCtx struct {
 
 func (lwc *logWithCtx) get(name string) any {
 	switch name {
-	case "task_id":
-		return wctx.TaskID(lwc.ctx)
+	case "src_name":
+		return wctx.SrcName(lwc.ctx)
+	case "intg_name":
+		return wctx.IntgName(lwc.ctx)
 	case "chain_id":
 		return wctx.ChainID(lwc.ctx)
 	case "block_hash":

--- a/cmd/e2pg/main.go
+++ b/cmd/e2pg/main.go
@@ -60,13 +60,6 @@ func main() {
 		}
 		return "chain", fmt.Sprintf("%.5d", id)
 	})
-	lh.RegisterContext(func(ctx context.Context) (string, any) {
-		id := wctx.TaskID(ctx)
-		if id == "" {
-			return "", nil
-		}
-		return "task", id
-	})
 	slog.SetDefault(slog.New(lh.WithAttrs([]slog.Attr{
 		slog.Int("p", os.Getpid()),
 		slog.String("v", Commit),
@@ -126,7 +119,7 @@ func main() {
 		check(pprof.StartCPUProfile(&pbuf))
 	}
 
-	go mgr.Run()
+	check(mgr.Run())
 
 	switch profile {
 	case "cpu":

--- a/e2pg/e2pg_test.go
+++ b/e2pg/e2pg_test.go
@@ -86,8 +86,6 @@ type testGeth struct {
 	blocks []eth.Block
 }
 
-func (tg *testGeth) ChainID() uint64 { return 0 }
-
 func (tg *testGeth) Hash(n uint64) ([]byte, error) {
 	for j := range tg.blocks {
 		if uint64(tg.blocks[j].Header.Number) == n {
@@ -144,7 +142,7 @@ func TestSetup(t *testing.T) {
 		tg   = &testGeth{}
 		pg   = testpg(t)
 		task = NewTask(
-			WithSource(tg),
+			WithSource(0, "1", tg),
 			WithPG(pg),
 			WithDestinations(newTestDestination()),
 		)
@@ -165,7 +163,7 @@ func TestConverge_Zero(t *testing.T) {
 		tg   = &testGeth{}
 		pg   = testpg(t)
 		task = NewTask(
-			WithSource(tg),
+			WithSource(0, "1", tg),
 			WithPG(pg),
 			WithDestinations(newTestDestination()),
 		)
@@ -179,7 +177,7 @@ func TestConverge_EmptyDestination(t *testing.T) {
 		tg   = &testGeth{}
 		dest = newTestDestination()
 		task = NewTask(
-			WithSource(tg),
+			WithSource(0, "1", tg),
 			WithPG(pg),
 			WithDestinations(dest),
 		)
@@ -198,7 +196,7 @@ func TestConverge_Reorg(t *testing.T) {
 		tg   = &testGeth{}
 		dest = newTestDestination()
 		task = NewTask(
-			WithSource(tg),
+			WithSource(0, "1", tg),
 			WithPG(pg),
 			WithDestinations(dest),
 		)
@@ -229,7 +227,7 @@ func TestConverge_DeltaBatchSize(t *testing.T) {
 		tg   = &testGeth{}
 		dest = newTestDestination()
 		task = NewTask(
-			WithSource(tg),
+			WithSource(0, "1", tg),
 			WithPG(pg),
 			WithConcurrency(workers, batchSize),
 			WithDestinations(dest),
@@ -258,13 +256,14 @@ func TestConverge_MultipleTasks(t *testing.T) {
 		dest1 = newTestDestination()
 		dest2 = newTestDestination()
 		task1 = NewTask(
-			WithSource(tg),
+			WithSource(0, "1", tg),
 			WithPG(pg),
 			WithConcurrency(1, 3),
 			WithDestinations(dest1),
 		)
 		task2 = NewTask(
-			WithBackfillSource(tg, "foo"),
+			WithSource(0, "1", tg),
+			WithBackfill(true),
 			WithPG(pg),
 			WithConcurrency(1, 3),
 			WithDestinations(dest2),
@@ -289,7 +288,7 @@ func TestConverge_LocalAhead(t *testing.T) {
 		pg   = testpg(t)
 		dest = newTestDestination()
 		task = NewTask(
-			WithSource(tg),
+			WithSource(0, "1", tg),
 			WithPG(pg),
 			WithConcurrency(1, 3),
 			WithDestinations(dest),

--- a/e2pg/integration_test.go
+++ b/e2pg/integration_test.go
@@ -66,7 +66,7 @@ func (th *Helper) Process(dest Destination, n uint64) {
 	var (
 		geth = NewGeth(th.gt.FileCache, th.gt.Client)
 		task = NewTask(
-			WithSource(geth),
+			WithSource(0, "", geth),
 			WithPG(th.PG),
 			WithDestinations(dest),
 		)

--- a/e2pg/migrations.go
+++ b/e2pg/migrations.go
@@ -34,4 +34,15 @@ var Migrations = map[int]pgmig.Migration{
 			alter table e2pg.task add column dstat jsonb;
 		`,
 	},
+	11: pgmig.Migration{
+		SQL: `
+				delete from e2pg.task where insert_at < now() - '2 hours'::interval;
+				alter table e2pg.task add column backfill bool default false;
+				alter table e2pg.task add column src_name text;
+				update e2pg.task set src_name = split_part(id, '-', 1);
+				alter table e2pg.task drop column id;
+				create unique index on e2pg.task(src_name, num desc) where backfill = true;
+				create unique index on e2pg.task(src_name, num desc) where backfill = false;
+			`,
+	},
 }

--- a/e2pg/schema.sql
+++ b/e2pg/schema.sql
@@ -44,7 +44,6 @@ CREATE TABLE e2pg.sources (
 
 
 CREATE TABLE e2pg.task (
-    id text NOT NULL,
     num bigint,
     hash bytea,
     insert_at timestamp with time zone DEFAULT now(),
@@ -53,7 +52,9 @@ CREATE TABLE e2pg.task (
     nblocks numeric,
     nrows numeric,
     latency interval,
-    dstat jsonb
+    dstat jsonb,
+    backfill boolean DEFAULT false,
+    src_name text
 );
 
 
@@ -71,7 +72,11 @@ CREATE UNIQUE INDEX sources_name_idx ON e2pg.sources USING btree (name);
 
 
 
-CREATE INDEX task_id_number_idx ON e2pg.task USING btree (id, num DESC);
+CREATE INDEX task_src_name_num_idx ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = true);
+
+
+
+CREATE INDEX task_src_name_num_idx1 ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = false);
 
 
 

--- a/e2pg/web/index.html
+++ b/e2pg/web/index.html
@@ -111,9 +111,8 @@
 		</div>
 		<div class="tasks">
 			{{ range $sc := .SourceConfigs -}}
-				{{ $tid  := (printf "%d-main" $sc.ChainID) -}}
-				{{ with $tu := (index $.TaskUpdates $tid) -}}
-				<div class="task" id="{{ $tid }}">
+				{{ with $tu := (index $.TaskUpdates $sc.Name) -}}
+				<div class="task" id="{{ $sc.Name }}">
 					<div class="source">
 						<div class="Name">{{ $sc.Name }}</div>
 						<div class="NRows">{{ $tu.NRows }}</div>
@@ -123,7 +122,7 @@
 					</div>
 					<div class="destinations" style="display:none;">
 						{{ range $name, $stat := $tu.Dstat -}}
-						<div class="destination" id="{{ $tu.ID }}-{{$name}}">
+						<div class="destination" id="{{ $tu.SrcName }}-{{$name}}">
 							<div class="Name">{{ $name }}</div>
 							<div class="NRows">{{ $stat.NRows }}</div>
 							<div class="Latency">{{ $stat.Latency }}</div>
@@ -160,13 +159,13 @@
 			let updates = new EventSource("/task-updates");
 			updates.onmessage = function(event) {
 				const tu = JSON.parse(event.data);
-				update(tu.ID, "Num", comma(tu.Num));
-				update(tu.ID, "Hash", tu.Hash);
-				update(tu.ID, "Latency", tu.Latency);
-				update(tu.ID, "NRows", tu.NRows);
+				update(tu.SrcName, "Num", comma(tu.Num));
+				update(tu.SrcName, "Hash", tu.Hash);
+				update(tu.SrcName, "Latency", tu.Latency);
+				update(tu.SrcName, "NRows", tu.NRows);
 				for (const [k1, v1] of Object.entries(tu.Dstat)) {
 					for (const [k2, v2] of Object.entries(v1)) {
-						update(`${tu.ID}-${k1}`, k2, v2);
+						update(`${tu.SrcName}-${k1}`, k2, v2);
 					}
 				}
 			};

--- a/wctx/ctx.go
+++ b/wctx/ctx.go
@@ -6,8 +6,9 @@ import "context"
 type key int
 
 const (
-	taskIDKey  key = 1
-	chainIDKey key = 2
+	chainIDKey  key = 1
+	intgNameKey key = 2
+	srcNameKey  key = 3
 )
 
 func WithChainID(ctx context.Context, id uint64) context.Context {
@@ -18,11 +19,21 @@ func ChainID(ctx context.Context) uint64 {
 	id, _ := ctx.Value(chainIDKey).(uint64)
 	return id
 }
-func WithTaskID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, taskIDKey, id)
+
+func WithIntgName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, intgNameKey, name)
 }
 
-func TaskID(ctx context.Context) string {
-	id, _ := ctx.Value(taskIDKey).(string)
-	return id
+func IntgName(ctx context.Context) string {
+	name, _ := ctx.Value(intgNameKey).(string)
+	return name
+}
+
+func WithSrcName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, srcNameKey, name)
+}
+
+func SrcName(ctx context.Context) string {
+	name, _ := ctx.Value(srcNameKey).(string)
+	return name
 }


### PR DESCRIPTION
This change is needed for the new backfill model. The goal is to remove the notion of creating tasks from E2PG's API. Instead, E2PG will use the config to determine which tasks need to be created. Each ETH source will have a main task and a backfill task. A task will be identified by it's src_name and backfill columns.