### PR TITLE
e2pg: add integration update table

### DIFF
--- a/cmd/e2pg/main.go
+++ b/cmd/e2pg/main.go
@@ -119,6 +119,13 @@ func main() {
 		check(pprof.StartCPUProfile(&pbuf))
 	}
 
+	go func() {
+		for {
+			check(e2pg.PruneIntg(ctx, pg, 200))
+			check(e2pg.PruneTask(ctx, pg, 200))
+			time.Sleep(time.Minute * 10)
+		}
+	}()
 	check(mgr.Run())
 
 	switch profile {

--- a/e2pg/iub_test.go
+++ b/e2pg/iub_test.go
@@ -1,0 +1,65 @@
+package e2pg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"blake.io/pqx/pqxtest"
+	"github.com/indexsupply/x/wpg"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"kr.dev/diff"
+)
+
+func TestPruneIntg(t *testing.T) {
+	ctx := context.Background()
+
+	pqxtest.CreateDB(t, Schema)
+	pg, err := pgxpool.New(ctx, pqxtest.DSNForTest(t))
+	diff.Test(t, t.Fatalf, err, nil)
+
+	iub := newIUB(1)
+	iub.updates[0].Name = "foo"
+	iub.updates[0].SrcName = "bar"
+	iub.updates[0].Num = 1
+
+	err = iub.write(ctx, pg)
+	diff.Test(t, t.Fatalf, err, nil)
+	checkQuery(t, pg, `select count(*) = 1 from e2pg.intg`)
+
+	err = iub.write(ctx, pg)
+	if err == nil || !strings.Contains(err.Error(), "intg_name_src_name_num_idx1") {
+		t.Errorf("expected 2nd write to return unique error")
+	}
+
+	for i := 0; i < 10; i++ {
+		iub.updates[0].Num = uint64(i + 2)
+		err := iub.write(ctx, pg)
+		diff.Test(t, t.Fatalf, err, nil)
+	}
+	checkQuery(t, pg, `select count(*) = 11 from e2pg.intg`)
+	err = PruneIntg(ctx, pg, 10)
+	diff.Test(t, t.Fatalf, err, nil)
+	checkQuery(t, pg, `select count(*) = 10 from e2pg.intg`)
+
+	iub.updates[0].Name = "foo"
+	iub.updates[0].SrcName = "baz"
+	iub.updates[0].Num = 1
+	err = iub.write(ctx, pg)
+	diff.Test(t, t.Fatalf, err, nil)
+	checkQuery(t, pg, `select count(*) = 1 from e2pg.intg where src_name = 'baz'`)
+	checkQuery(t, pg, `select count(*) = 11 from e2pg.intg`)
+
+	err = PruneIntg(ctx, pg, 10)
+	diff.Test(t, t.Fatalf, err, nil)
+	checkQuery(t, pg, `select count(*) = 11 from e2pg.intg`)
+}
+
+func checkQuery(tb testing.TB, pg wpg.Conn, query string) {
+	var found bool
+	err := pg.QueryRow(context.Background(), query).Scan(&found)
+	diff.Test(tb, tb.Fatalf, err, nil)
+	if !found {
+		tb.Errorf("query\n%s\nreturned false", query)
+	}
+}

--- a/e2pg/migrations.go
+++ b/e2pg/migrations.go
@@ -36,13 +36,27 @@ var Migrations = map[int]pgmig.Migration{
 	},
 	11: pgmig.Migration{
 		SQL: `
-				delete from e2pg.task where insert_at < now() - '2 hours'::interval;
-				alter table e2pg.task add column backfill bool default false;
-				alter table e2pg.task add column src_name text;
-				update e2pg.task set src_name = split_part(id, '-', 1);
-				alter table e2pg.task drop column id;
-				create unique index on e2pg.task(src_name, num desc) where backfill = true;
-				create unique index on e2pg.task(src_name, num desc) where backfill = false;
-			`,
+			delete from e2pg.task where insert_at < now() - '2 hours'::interval;
+			alter table e2pg.task add column backfill bool default false;
+			alter table e2pg.task add column src_name text;
+			update e2pg.task set src_name = split_part(id, '-', 1);
+			alter table e2pg.task drop column id;
+			create unique index on e2pg.task(src_name, num desc) where backfill = true;
+			create unique index on e2pg.task(src_name, num desc) where backfill = false;
+		`,
+	},
+	12: pgmig.Migration{
+		SQL: `
+			create table e2pg.intg (
+				name text not null,
+				src_name text not null,
+				backfill bool default false,
+				num numeric not null,
+				latency interval,
+				nrows numeric
+			);
+			create unique index on e2pg.intg(name, src_name, num desc) where backfill;
+			create unique index on e2pg.intg(name, src_name, num desc) where not backfill;
+		`,
 	},
 }

--- a/e2pg/schema.sql
+++ b/e2pg/schema.sql
@@ -27,6 +27,17 @@ CREATE TABLE e2pg.integrations (
 
 
 
+CREATE TABLE e2pg.intg (
+    name text NOT NULL,
+    src_name text NOT NULL,
+    backfill boolean DEFAULT false,
+    num numeric NOT NULL,
+    latency interval,
+    nrows numeric
+);
+
+
+
 CREATE TABLE e2pg.migrations (
     idx integer NOT NULL,
     hash bytea NOT NULL,
@@ -64,6 +75,14 @@ ALTER TABLE ONLY e2pg.migrations
 
 
 
+CREATE UNIQUE INDEX intg_name_src_name_num_idx ON e2pg.intg USING btree (name, src_name, num DESC) WHERE backfill;
+
+
+
+CREATE UNIQUE INDEX intg_name_src_name_num_idx1 ON e2pg.intg USING btree (name, src_name, num DESC) WHERE (NOT backfill);
+
+
+
 CREATE UNIQUE INDEX sources_name_chain_id_idx ON e2pg.sources USING btree (name, chain_id);
 
 
@@ -72,11 +91,11 @@ CREATE UNIQUE INDEX sources_name_idx ON e2pg.sources USING btree (name);
 
 
 
-CREATE INDEX task_src_name_num_idx ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = true);
+CREATE UNIQUE INDEX task_src_name_num_idx ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = true);
 
 
 
-CREATE INDEX task_src_name_num_idx1 ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = false);
+CREATE UNIQUE INDEX task_src_name_num_idx1 ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = false);
 
 
 


### PR DESCRIPTION
This table will be used to control backfill tasks. The task table keeps a history of blocks processed, but they are used for detecting a re-organization. It does not track an integration's individual progress.

By introducing the intg table, we now can know the precise set of blocks that an integration has processed.

This will enable a backfill task to group a set of integrations that need backfilling and process block history based on the needs of the integration.

This commit also introduces the notion of e2pg.{task,intg} pruning. We keep around the last 200 blocks for each src_name / src_name,name. This should help keep queries on this table fast while also preserving history for reorgs and debugging.