### PR TITLE
abi2: validate integration. add required columns

### DIFF
--- a/abi2/abi2_test.go
+++ b/abi2/abi2_test.go
@@ -311,3 +311,48 @@ func TestNumIndexed(t *testing.T) {
 	}
 	diff.Test(t, t.Errorf, 3, event.numIndexed())
 }
+
+func TestValidate_AddRequired(t *testing.T) {
+	ig := Integration{
+		name: "foo",
+		Table: Table{
+			Name: "foo",
+			Cols: []Column{
+				Column{Name: "b", Type: "bytea"},
+				Column{Name: "c", Type: "bytea"},
+			},
+		},
+		Event: Event{
+			Name: "bar",
+			Inputs: []Input{
+				Input{Indexed: true, Name: "a"},
+				Input{Indexed: true, Name: "b", Column: "b"},
+				Input{Indexed: true, Name: "c", Column: "c"},
+			},
+		},
+	}
+	diff.Test(t, t.Errorf, nil, ig.validate())
+	diff.Test(t, t.Errorf, 5, len(ig.Table.Cols))
+}
+
+func TestValidate_MissingCols(t *testing.T) {
+	ig := Integration{
+		name: "foo",
+		Table: Table{
+			Name: "foo",
+			Cols: []Column{
+				Column{Name: "c", Type: "bytea"},
+			},
+		},
+		Event: Event{
+			Name: "bar",
+			Inputs: []Input{
+				Input{Indexed: true, Name: "a"},
+				Input{Indexed: true, Name: "b", Column: "b"},
+				Input{Indexed: true, Name: "c", Column: "c"},
+			},
+		},
+	}
+	const want = "validating columns: missing column for b"
+	diff.Test(t, t.Errorf, want, ig.validate().Error())
+}

--- a/e2pg/e2pg.go
+++ b/e2pg/e2pg.go
@@ -1020,8 +1020,8 @@ func getDest(pgp *pgxpool.Pool, ig Integration) (Destination, error) {
 		if err != nil {
 			return nil, fmt.Errorf("building abi integration: %w", err)
 		}
-		if err := abi2.CreateTable(context.Background(), pgp, aig.Table); err != nil {
-			return nil, fmt.Errorf("setting up table for abi integration: %w", err)
+		if err := aig.Table.Create(context.Background(), pgp); err != nil {
+			return nil, fmt.Errorf("create intg table: %w", err)
 		}
 		return aig, nil
 	}


### PR DESCRIPTION
In order for the abi2 package to properly delete
data during a reorg, we needed to make sure that we have
intg_name, src_name, and block_num columns available.
    
Additionally, this code sanitizes user input for table and column names
since we are building sql strings without bind parameters.