### PR TITLE
e2pg: improve task manager setup

### DIFF
--- a/cmd/e2pg/main.go
+++ b/cmd/e2pg/main.go
@@ -131,8 +131,7 @@ func main() {
 		}
 	}()
 
-	check(mgr.Load())
-	mgr.Run()
+	go mgr.Run()
 
 	switch profile {
 	case "cpu":

--- a/e2pg/web/web.go
+++ b/e2pg/web/web.go
@@ -138,12 +138,12 @@ func (h *Handler) SaveIntegration(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if err := h.mgr.Load(); err != nil {
+	h.mgr.Restart()
+	if err := h.mgr.Err(); err != nil {
 		slog.ErrorContext(ctx, "inserting integration", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	h.mgr.Restart()
 	json.NewEncoder(w).Encode("ok")
 }
 
@@ -313,11 +313,11 @@ func (h *Handler) SaveSource(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(ctx, "inserting task", err)
 		return
 	}
-	if err := h.mgr.Load(); err != nil {
+	h.mgr.Restart()
+	if err := h.mgr.Err(); err != nil {
 		slog.ErrorContext(ctx, "inserting integration", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	h.mgr.Restart()
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }


### PR DESCRIPTION
Having the loadTasks and task.Setup function execute within the task manager's mutex is nice because it makes it easy to reason about order of events. In particular, task setup may insert into the intg table for backfill tasks. If there is already a backfill task underway, we are changing the intg table under the feet of the currently running backfill task. It's much simpler to assume that a single writer is writing to the intg table on behalf of a src/task/backfill combination.