### PR TITLE
e2pg: fix tx.type parsing and add extraction support

### DIFF
--- a/abi2/abi2.go
+++ b/abi2/abi2.go
@@ -894,6 +894,8 @@ func (lwc *logWithCtx) get(name string) any {
 		return lwc.t.Value.Dec()
 	case "tx_input":
 		return lwc.t.Data.Bytes()
+	case "tx_type":
+		return lwc.t.Type
 	case "log_idx":
 		return lwc.lidx
 	case "log_addr":

--- a/eth/types.go
+++ b/eth/types.go
@@ -73,8 +73,9 @@ func (hb *hbyte) UnmarshalJSON(data []byte) error {
 	}
 	data = data[1 : len(data)-1] // remove quotes
 	data = data[2:]              // remove 0x
-	*hb = hbyte(data[0])
-	return nil
+	n, err := decode(string(data))
+	*hb = hbyte(n)
+	return err
 }
 
 type Bytes []byte


### PR DESCRIPTION
Right now there's no support for extracting tx_type so I added that in. This is especially useful for Arbitrum chains that support different txn types: https://docs.arbitrum.io/for-devs/concepts/differences-between-arbitrum-ethereum/rpc-methods.

Additionally, the json unmarshaling code incorrectly returns the first byte of a hex string. For example, "0x6a" would return the decimal value 54 because the code returns `hbyte("6")` which is the ascii value of "6".