### PR TITLE
e2pg: s/intg/ig

### DIFF
--- a/abi2/abi2_test.go
+++ b/abi2/abi2_test.go
@@ -340,7 +340,7 @@ func TestNew(t *testing.T) {
 		"b",
 		"c",
 		"block_num",
-		"intg_name",
+		"ig_name",
 		"src_name",
 		"tx_idx",
 		"log_idx",
@@ -372,7 +372,7 @@ func TestValidate_AddRequired(t *testing.T) {
 	want := []Column{
 		{Name: "b", Type: "bytea"},
 		{Name: "c", Type: "bytea"},
-		{Name: "intg_name", Type: "text"},
+		{Name: "ig_name", Type: "text"},
 		{Name: "src_name", Type: "text"},
 		{Name: "block_num", Type: "numeric"},
 		{Name: "tx_idx", Type: "int4"},
@@ -408,7 +408,7 @@ func TestAddUniqueIndex(t *testing.T) {
 	ig.addRequiredFields()
 	ig.setCols()
 	ig.addUniqueIndex()
-	want := []string{"intg_name", "src_name", "block_num", "tx_idx"}
+	want := []string{"ig_name", "src_name", "block_num", "tx_idx"}
 	diff.Test(t, t.Fatalf, 1, len(ig.Table.Unique))
 	diff.Test(t, t.Errorf, want, ig.Table.Unique[0])
 }

--- a/cmd/e2pg/main.go
+++ b/cmd/e2pg/main.go
@@ -132,7 +132,7 @@ func main() {
 
 	go func() {
 		for {
-			check(e2pg.PruneIntg(ctx, pg))
+			check(e2pg.PruneIG(ctx, pg))
 			check(e2pg.PruneTask(ctx, pg, 200))
 			time.Sleep(time.Minute * 10)
 		}

--- a/docs/e2pg/readme.md
+++ b/docs/e2pg/readme.md
@@ -123,7 +123,6 @@ Integrations are specified using the config file. Here is an example of an integ
     "table": {
         "name": "erc20_transfers",
         "columns": [
-            {"name": "task_id", "type": "text"},
             {"name": "chain_id", "type": "numeric"},
             {"name": "block_num", "type": "numeric"},
             {"name": "tx_hash", "type": "bytea"},
@@ -134,7 +133,6 @@ Integrations are specified using the config file. Here is an example of an integ
         ]
     },
     "block": [
-        {"name": "task_id", "column": "task_id"},
         {"name": "chain_id", "column": "chain_id"},
         {"name": "block_num", "column": "block_num"},
         {"name": "tx_hash", "column": "tx_hash"},
@@ -179,7 +177,8 @@ The table is created dynamically. If the table already exists, nothing is change
 
 Instructs the integration to retrieve block level data. The available data include:
 
-- task_id, text (e2pg internal bookkeeping)
+- src_name, text (e2pg internal bookkeeping)
+- ig_name, text (e2pg internal bookkeeping)
 - chain_id, numeric
 - block_hash, bytea
 - block_num, numeric
@@ -209,7 +208,7 @@ The event is a ABI fragment containing an ABI JSON event definition. However, an
 If E2PG gets a block from its Ethereum source where the new block's parent doesn't match the local block's hash, then the local block, and all it's integration data are deleted. After the deletion, E2PG attempts to add the new block. This process is repeated up to 10 times or until a hash/parent match is made. If there is a reorg of more than 10 blocks the database transaction is rolled back (meaning no data was deleted) and E2PG will halt progress. This condition requires operator intervention via SQL:
 
 ```sql
-delete from e2pg.task where number > XXX;
+delete from e2pg.task_updates where number > XXX;
 --etc...
 ```
 

--- a/e2pg/integration_test.go
+++ b/e2pg/integration_test.go
@@ -47,7 +47,7 @@ func NewHelper(tb testing.TB) *Helper {
 
 // Reset the task table. Call this in-between test cases
 func (th *Helper) Reset() {
-	_, err := th.PG.Exec(context.Background(), "truncate table e2pg.task")
+	_, err := th.PG.Exec(context.Background(), "truncate table e2pg.task_updates")
 	check(th.tb, err)
 }
 

--- a/e2pg/migrations.go
+++ b/e2pg/migrations.go
@@ -77,4 +77,10 @@ var Migrations = map[int]pgmig.Migration{
 			alter table e2pg.task drop column dstat;
 		`,
 	},
+	16: pgmig.Migration{
+		SQL: `
+			alter table e2pg.task rename to task_updates;
+			alter table e2pg.intg rename to ig_updates;
+		`,
+	},
 }

--- a/e2pg/schema.sql
+++ b/e2pg/schema.sql
@@ -20,14 +20,7 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 
-CREATE TABLE e2pg.integrations (
-    name text,
-    conf jsonb
-);
-
-
-
-CREATE TABLE e2pg.intg (
+CREATE TABLE e2pg.ig_updates (
     name text NOT NULL,
     src_name text NOT NULL,
     backfill boolean DEFAULT false,
@@ -35,6 +28,13 @@ CREATE TABLE e2pg.intg (
     latency interval,
     nrows numeric,
     stop numeric
+);
+
+
+
+CREATE TABLE e2pg.integrations (
+    name text,
+    conf jsonb
 );
 
 
@@ -55,7 +55,7 @@ CREATE TABLE e2pg.sources (
 
 
 
-CREATE TABLE e2pg.task (
+CREATE TABLE e2pg.task_updates (
     num bigint,
     hash bytea,
     insert_at timestamp with time zone DEFAULT now(),
@@ -76,7 +76,7 @@ ALTER TABLE ONLY e2pg.migrations
 
 
 
-CREATE UNIQUE INDEX intg_name_src_name_backfill_num_idx ON e2pg.intg USING btree (name, src_name, backfill, num DESC);
+CREATE UNIQUE INDEX intg_name_src_name_backfill_num_idx ON e2pg.ig_updates USING btree (name, src_name, backfill, num DESC);
 
 
 
@@ -88,11 +88,11 @@ CREATE UNIQUE INDEX sources_name_idx ON e2pg.sources USING btree (name);
 
 
 
-CREATE UNIQUE INDEX task_src_name_num_idx ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = true);
+CREATE UNIQUE INDEX task_src_name_num_idx ON e2pg.task_updates USING btree (src_name, num DESC) WHERE (backfill = true);
 
 
 
-CREATE UNIQUE INDEX task_src_name_num_idx1 ON e2pg.task USING btree (src_name, num DESC) WHERE (backfill = false);
+CREATE UNIQUE INDEX task_src_name_num_idx1 ON e2pg.task_updates USING btree (src_name, num DESC) WHERE (backfill = false);
 
 
 

--- a/e2pg/web/index.html
+++ b/e2pg/web/index.html
@@ -146,7 +146,7 @@
 						<div class="Progress">-</div>
 					</div>
 					<div class="destinations" style="display:none;">
-						{{ range $iu := (index $.IntgUpdates $tu.DOMID) -}}
+						{{ range $iu := (index $.IGUpdates $tu.DOMID) -}}
 						<div class="destination" id="{{ $iu.DOMID }}">
 							<div class="Name">{{ $iu.Name }}</div>
 							<div class="NRows">{{ $iu.NRows }}</div>
@@ -177,7 +177,7 @@
 						<div class="Progress">-</div>
 					</div>
 					<div class="destinations" style="display:none;">
-						{{ range $iu := (index $.IntgUpdates $tu.DOMID) -}}
+						{{ range $iu := (index $.IGUpdates $tu.DOMID) -}}
 						<div class="destination" id="{{ $iu.DOMID }}">
 							<div class="Name">{{ $iu.Name }}</div>
 							<div class="NRows">{{ $iu.NRows }}</div>

--- a/wctx/ctx.go
+++ b/wctx/ctx.go
@@ -7,7 +7,7 @@ type key int
 
 const (
 	chainIDKey  key = 1
-	intgNameKey key = 2
+	igNameKey   key = 2
 	srcNameKey  key = 3
 	backfillKey key = 4
 )
@@ -21,12 +21,12 @@ func ChainID(ctx context.Context) uint64 {
 	return id
 }
 
-func WithIntgName(ctx context.Context, name string) context.Context {
-	return context.WithValue(ctx, intgNameKey, name)
+func WithIGName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, igNameKey, name)
 }
 
-func IntgName(ctx context.Context) string {
-	name, _ := ctx.Value(intgNameKey).(string)
+func IGName(ctx context.Context) string {
+	name, _ := ctx.Value(igNameKey).(string)
 	return name
 }
 


### PR DESCRIPTION
I go back and forth on var names. I tend to like short names for small functions and non-abbreviated names for global concepts. However, integration is a very long word. It's a PITA when grepping logs of writing sql queries. To that end, I'm going to use IG for exported, abbreviated references to Integration and ig for un-exported, abbreviated references.